### PR TITLE
[CI] Add GitHub workflows to build maven and publish container.

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,31 @@
+name: pull-request
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  maven-build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup Maven Action
+        uses: s4u/setup-maven-action@v1.2.1
+        with:
+          java-version: '11'
+          maven-version: '3.8.2'
+
+      - name: Build with Maven
+        run: mvn -B install
+
+  container-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build container
+        run: docker build .

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -1,0 +1,73 @@
+name: release-next
+
+on:
+  push:
+    branches:
+      - next
+  workflow_dispatch:
+
+jobs:
+  maven-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 11.0.2
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: 11.0
+          server-id: github
+
+      # get the id of the latest SNAPSHOT version
+      - uses: octokit/graphql-action@v2.x
+        id: get_latest_snapshot_version
+        with:
+          query: |
+            query SnapshotVersion($owner:String!,$repo:String!,$pkg:String!) {
+              repository(owner:$owner,name:$repo) {
+                packages(names:[$pkg],first: 1) {
+                  nodes {
+                    versions(first:1) {
+                      nodes {
+                        id,
+                        version
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          owner: ${{ github.event.repository.owner.login }}
+          repo: ${{ github.event.repository.name }}
+          pkg: 'at.ac.tuwien.damap-backend'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # remove the package with the latest SNAPSHOT version, because GitHub Packages currently doesn't support mutable
+      # package versions
+      - uses: actions/delete-package-versions@v3
+        id: delete_current_snapshot_version
+        with:
+          package-name: 'at.ac.tuwien.damap-backend'
+          package-version-ids: '${{ fromJSON(steps.get_latest_snapshot_version.outputs.data).repository.packages.nodes[0].versions.nodes[0].id }}'
+
+      - name: Publish to GitHub packages
+        run: mvn -B clean deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  container-build-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Publish to Registry
+        uses: minddocdev/docker-publish-action@master
+        with:
+          name: tuwien-csd/damap-backend/damap-backend
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: release
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  maven-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 11.0.2
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: 11.0
+          server-id: github
+
+      - name: Publish to GitHub packages
+        run: mvn -B clean deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  container-build-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Publish to Registry
+        uses: minddocdev/docker-publish-action@master
+        with:
+          name: tuwien-csd/damap-backend/damap-backend
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io


### PR DESCRIPTION
* The PullRequest workflow would automatically build the maven project and the container.
* Release next automatically publishes a SNAPSHOT version with container
* Release master builds maven release and a container image

Maven artifacts and container images are hosted at github packages, thus we and collaborators can pull maven dependencies from Githubs public repository.