### PR TITLE
Allow frontend to request export for a specific template,

### DIFF
--- a/src/main/java/at/ac/tuwien/damap/conversion/ExportFWFTemplate.java
+++ b/src/main/java/at/ac/tuwien/damap/conversion/ExportFWFTemplate.java
@@ -11,6 +11,7 @@ import java.util.*;
 public class ExportFWFTemplate extends AbstractTemplateExportScienceEuropeComponents {
 
     public XWPFDocument exportTemplate(long dmpId) {
+        log.info("Exporting FWF document for DMP with ID: " + dmpId);
         //load project
         exportSetup(dmpId);
         //load template and properties

--- a/src/main/java/at/ac/tuwien/damap/conversion/ExportScienceEuropeTemplate.java
+++ b/src/main/java/at/ac/tuwien/damap/conversion/ExportScienceEuropeTemplate.java
@@ -10,6 +10,7 @@ import javax.enterprise.context.ApplicationScoped;
 public class ExportScienceEuropeTemplate extends AbstractTemplateExportScienceEuropeComponents {
 
     public XWPFDocument exportTemplate(long dmpId) {
+        log.info("Exporting Science Europe document for DMP with ID: " + dmpId);
         //load project
         exportSetup(dmpId);
         //load template and properties

--- a/src/main/java/at/ac/tuwien/damap/conversion/ExportTemplateBroker.java
+++ b/src/main/java/at/ac/tuwien/damap/conversion/ExportTemplateBroker.java
@@ -1,6 +1,7 @@
 package at.ac.tuwien.damap.conversion;
 
 import at.ac.tuwien.damap.enums.EIdentifierType;
+import at.ac.tuwien.damap.enums.ETemplateType;
 import at.ac.tuwien.damap.rest.dmp.domain.DmpDO;
 import at.ac.tuwien.damap.rest.dmp.domain.IdentifierDO;
 import at.ac.tuwien.damap.rest.dmp.service.DmpService;
@@ -30,7 +31,7 @@ public class ExportTemplateBroker {
      * @param dmpId
      * @return
      */
-    public XWPFDocument exportTemplate(long dmpId){
+    public XWPFDocument exportTemplate(long dmpId) {
         DmpDO dmpDO = dmpService.getDmpById(dmpId);
         if (dmpDO.getProject() != null)
             if (dmpDO.getProject().getFunding() != null)
@@ -46,5 +47,15 @@ public class ExportTemplateBroker {
 
         //default export science europe template
         return exportScienceEuropeTemplate.exportTemplate(dmpId);
+    }
+
+    public XWPFDocument exportTemplateByType(long dmpId, ETemplateType type) {
+        switch (type) {
+            case FWF:
+                return exportFWFTemplate.exportTemplate(dmpId);
+            case SCIENCE_EUROPE:
+            default:
+                return exportScienceEuropeTemplate.exportTemplate(dmpId);
+        }
     }
 }

--- a/src/main/java/at/ac/tuwien/damap/enums/ETemplateType.java
+++ b/src/main/java/at/ac/tuwien/damap/enums/ETemplateType.java
@@ -1,0 +1,39 @@
+package at.ac.tuwien.damap.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.HashMap;
+
+public enum ETemplateType {
+
+    SCIENCE_EUROPE("SCIENCE_EUROPE"),
+    FWF("FWF");
+
+    private final String value;
+
+    private static final HashMap<String, ETemplateType> MAP = new HashMap<String, ETemplateType>();
+
+    ETemplateType(String value) {
+        this.value = value;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return value;
+    }
+
+    public String getValue() {
+        return this.value;
+    }
+
+    public static ETemplateType getByValue(String value) {
+        return MAP.get(value);
+    }
+
+    static {
+        for (ETemplateType type : ETemplateType.values()) {
+            MAP.put(type.getValue(), type);
+        }
+    }
+}

--- a/src/main/java/at/ac/tuwien/damap/rest/DmpDocumentResource.java
+++ b/src/main/java/at/ac/tuwien/damap/rest/DmpDocumentResource.java
@@ -1,6 +1,7 @@
 package at.ac.tuwien.damap.rest;
 
 import at.ac.tuwien.damap.conversion.ExportTemplateBroker;
+import at.ac.tuwien.damap.enums.ETemplateType;
 import at.ac.tuwien.damap.rest.dmp.service.DmpService;
 import at.ac.tuwien.damap.security.SecurityService;
 import at.ac.tuwien.damap.validation.AccessValidator;
@@ -37,7 +38,7 @@ public class DmpDocumentResource {
 
     @GET
     @Path("/{dmpId}")
-    public Response exportTemplate(@PathParam("dmpId") long dmpId) {
+    public Response exportTemplate(@PathParam("dmpId") long dmpId, @QueryParam("template") ETemplateType template) {
         log.info("Return DMP document file for DMP with id=" + dmpId);
 
         String personId = this.getPersonId();
@@ -47,7 +48,11 @@ public class DmpDocumentResource {
 
         String filename = dmpService.getDefaultFileName(dmpId);
 
-        XWPFDocument document = exportTemplateBroker.exportTemplate(dmpId);
+        XWPFDocument document;
+        if (template != null)
+            document = exportTemplateBroker.exportTemplateByType(dmpId, template);
+        else
+            document = exportTemplateBroker.exportTemplate(dmpId);
 
         StreamingOutput streamingOutput = new StreamingOutput() {
             @Override

--- a/src/test/java/at/ac/tuwien/damap/rest/DmpDocumentResourceTest.java
+++ b/src/test/java/at/ac/tuwien/damap/rest/DmpDocumentResourceTest.java
@@ -63,4 +63,34 @@ public class DmpDocumentResourceTest {
                 .then()
                 .statusCode(200);
     }
+
+    @Test
+    @TestSecurity(user = "userJwt", roles = "user")
+    public void testExportTemplateEndpointWithTemplateTypeFWF_Valid() {
+        DmpDO dmpDO = testDOFactory.getOrCreateTestDmpDO();
+        given()
+                .when().get("/" + dmpDO.getId() + "?template=FWF")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    @TestSecurity(user = "userJwt", roles = "user")
+    public void testExportTemplateEndpointWithTemplateTypeScienceEurope_Valid() {
+        DmpDO dmpDO = testDOFactory.getOrCreateTestDmpDO();
+        given()
+                .when().get("/" + dmpDO.getId() + "?template=SCIENCE_EUROPE")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    @TestSecurity(user = "userJwt", roles = "user")
+    public void testExportTemplateEndpointWithTemplateType_Invalid() {
+        DmpDO dmpDO = testDOFactory.getOrCreateTestDmpDO();
+        given()
+                .when().get("/" + dmpDO.getId() + "?template=invalid")
+                .then()
+                .statusCode(404);
+    }
 }


### PR DESCRIPTION
refs https://github.com/tuwien-csd/damap-frontend/issues/58

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
Feature

The API requesting the exported template now allows to add an optional enum to request the export into a specific template type.
The change does not break the current functionality.


### Checks
- [x] Tested with Oracle/PostgreSQL
- [x] Tests added
- [ ] Successfully ran e2e tests before merge

backend solution for https://github.com/tuwien-csd/damap-frontend/issues/58
