### PR TITLE
[bugfix] adapt existing code to use new person services

### DIFF
--- a/src/main/java/at/ac/tuwien/damap/rest/PersonResource.java
+++ b/src/main/java/at/ac/tuwien/damap/rest/PersonResource.java
@@ -1,6 +1,5 @@
 package at.ac.tuwien.damap.rest;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -12,10 +11,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
-import at.ac.tuwien.damap.rest.config.domain.ServiceConfig;
 import at.ac.tuwien.damap.rest.dmp.domain.ContributorDO;
 import at.ac.tuwien.damap.rest.persons.PersonService;
-import io.quarkus.arc.All;
 import io.quarkus.security.Authenticated;
 import lombok.extern.jbosslog.JBossLog;
 
@@ -26,40 +23,15 @@ import lombok.extern.jbosslog.JBossLog;
 @JBossLog
 public class PersonResource {
 
-    LinkedHashMap<String, PersonService> personServices = new LinkedHashMap<String, PersonService>();
-
     @Inject
-    public PersonResource(ConfigResource config, @All List<PersonService> availableServices) {
-        List<ServiceConfig> configuredServices = config.personServiceConfigurations.getConfigs();
-
-        configuredServices.forEach(serviceConfig -> {
-            Boolean found = false;
-            String configClassName = serviceConfig.getClassName();
-            for (var service : availableServices) {
-                try {
-                    String serviceClassName = service.getClass().getCanonicalName().split("_ClientProxy")[0];
-
-                    if (configClassName.equals(serviceClassName)) {
-                        personServices.put(serviceConfig.getQueryValue(), service);
-                        found = true;
-                        break;
-                    }
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
-            if (!found) {
-                log.warn(String.format("Service '%s' configured but is not available", serviceConfig.getClassName()));
-            }
-        });
-    }
+    PersonServiceBroker personServiceBroker;
 
     @GET
     @Path("/{id}")
     public ContributorDO getPersonById(@PathParam("id") String id,
             @QueryParam("searchService") String searchServiceType) {
         log.info("Return person details for id=" + id);
-        PersonService searchService = getServiceForQueryParam(searchServiceType);
+        PersonService searchService = personServiceBroker.getServiceForQueryParam(searchServiceType);
 
         ContributorDO person = null;
         if (searchService != null) {
@@ -76,7 +48,7 @@ public class PersonResource {
 
         log.info("Return person list for query=" + searchTerm + "&searchService=" + searchServiceType);
 
-        PersonService searchService = getServiceForQueryParam(searchServiceType);
+        PersonService searchService = personServiceBroker.getServiceForQueryParam(searchServiceType);
 
         List<ContributorDO> persons = List.of();
         if (searchService != null) {
@@ -86,12 +58,5 @@ public class PersonResource {
         return persons;
     }
 
-    private PersonService getServiceForQueryParam(String searchServiceType) {
-        PersonService searchService = personServices.get(searchServiceType);
-        if (searchService == null && !personServices.isEmpty()) {
-            searchService = personServices.entrySet().iterator().next().getValue();
-        }
 
-        return searchService;
-    }
 }

--- a/src/main/java/at/ac/tuwien/damap/rest/PersonServiceBroker.java
+++ b/src/main/java/at/ac/tuwien/damap/rest/PersonServiceBroker.java
@@ -1,0 +1,53 @@
+package at.ac.tuwien.damap.rest;
+
+import at.ac.tuwien.damap.rest.config.domain.ServiceConfig;
+import at.ac.tuwien.damap.rest.persons.PersonService;
+import io.quarkus.arc.All;
+import lombok.extern.jbosslog.JBossLog;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+@JBossLog
+@ApplicationScoped
+public class PersonServiceBroker {
+
+    LinkedHashMap<String, PersonService> personServices = new LinkedHashMap<String, PersonService>();
+
+    @Inject
+    public PersonServiceBroker(ConfigResource config, @All List<PersonService> availableServices) {
+        List<ServiceConfig> configuredServices = config.personServiceConfigurations.getConfigs();
+
+        configuredServices.forEach(serviceConfig -> {
+            Boolean found = false;
+            String configClassName = serviceConfig.getClassName();
+            for (var service : availableServices) {
+                try {
+                    String serviceClassName = service.getClass().getCanonicalName().split("_ClientProxy")[0];
+
+                    if (configClassName.equals(serviceClassName)) {
+                        personServices.put(serviceConfig.getQueryValue(), service);
+                        found = true;
+                        break;
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+            if (!found) {
+                log.warn(String.format("Service '%s' configured but is not available", serviceConfig.getClassName()));
+            }
+        });
+    }
+
+    public PersonService getServiceForQueryParam(String searchServiceType) {
+        PersonService searchService = personServices.get(searchServiceType);
+        if (searchService == null && !personServices.isEmpty()) {
+            searchService = personServices.entrySet().iterator().next().getValue();
+        }
+
+        return searchService;
+    }
+}

--- a/src/main/java/at/ac/tuwien/damap/rest/access/mapper/AccessMapper.java
+++ b/src/main/java/at/ac/tuwien/damap/rest/access/mapper/AccessMapper.java
@@ -21,6 +21,7 @@ public class AccessMapper {
         accessDO.setUniversityId(access.getUniversityId());
         // Get name and mail for accesses from contributor list
         Optional<Contributor> contributor = access.getDmp().getContributorList().stream().filter(c ->
+                c.getUniversityId() != null &&
                 c.getUniversityId().equals(access.getUniversityId())).findFirst();
         if (contributor.isPresent()) {
             Contributor c = contributor.get();

--- a/src/main/java/at/ac/tuwien/damap/rest/access/service/AccessService.java
+++ b/src/main/java/at/ac/tuwien/damap/rest/access/service/AccessService.java
@@ -14,6 +14,7 @@ import lombok.extern.jbosslog.JBossLog;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.Date;
@@ -30,6 +31,7 @@ public class AccessService {
     DmpRepo dmpRepo;
 
     @Inject
+    @Named("UNIVERSITY")
     PersonService personService;
 
     @Inject

--- a/src/main/java/at/ac/tuwien/damap/rest/access/service/AccessService.java
+++ b/src/main/java/at/ac/tuwien/damap/rest/access/service/AccessService.java
@@ -24,6 +24,7 @@ import java.util.List;
 @JBossLog
 public class AccessService {
 
+    //defines which personService is to be used for access management
     private final String ENABLED_PERSON_SERVICE = "UNIVERSITY";
 
     @Inject
@@ -60,7 +61,7 @@ public class AccessService {
         // Get dmp contributors (viewers)
         dmp.getContributorList().forEach(contributor -> {
             // Only university members can be editors for now
-            if (contributor.getUniversityId() != null &&
+            if (contributor.getUniversityId() != null && !contributor.getUniversityId().isEmpty() &&
                 accessDOList.stream().noneMatch(a -> a.getUniversityId().equals(contributor.getUniversityId()))) {
                 ContributorDO contributorDO = new ContributorDO();
                 ContributorDOMapper.mapEntityToDO(contributor, contributorDO);

--- a/src/main/java/at/ac/tuwien/damap/rest/access/service/AccessService.java
+++ b/src/main/java/at/ac/tuwien/damap/rest/access/service/AccessService.java
@@ -10,11 +10,11 @@ import at.ac.tuwien.damap.rest.dmp.domain.ContributorDO;
 import at.ac.tuwien.damap.rest.dmp.mapper.ContributorDOMapper;
 import at.ac.tuwien.damap.rest.dmp.mapper.MapperService;
 import at.ac.tuwien.damap.rest.persons.PersonService;
+import at.ac.tuwien.damap.rest.PersonServiceBroker;
 import lombok.extern.jbosslog.JBossLog;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.Date;
@@ -24,6 +24,8 @@ import java.util.List;
 @JBossLog
 public class AccessService {
 
+    private final String ENABLED_PERSON_SERVICE = "UNIVERSITY";
+
     @Inject
     AccessRepo accessRepo;
 
@@ -31,13 +33,14 @@ public class AccessService {
     DmpRepo dmpRepo;
 
     @Inject
-    @Named("UNIVERSITY")
-    PersonService personService;
-
-    @Inject
     MapperService mapperService;
 
+    @Inject
+    PersonServiceBroker personServiceBroker;
+
     public List<ContributorDO> getByDmpId(long dmpId) {
+        PersonService personService = personServiceBroker.getServiceForQueryParam(ENABLED_PERSON_SERVICE);
+
         Dmp dmp = dmpRepo.findById(dmpId);
         // Get access list (owner, editors)
         List<ContributorDO> accessDOList = new ArrayList<>();

--- a/src/main/java/at/ac/tuwien/damap/rest/config/domain/ServiceConfig.java
+++ b/src/main/java/at/ac/tuwien/damap/rest/config/domain/ServiceConfig.java
@@ -1,8 +1,7 @@
 package at.ac.tuwien.damap.rest.config.domain;
 
-import javax.json.bind.annotation.JsonbTransient;
-
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -19,6 +18,6 @@ public class ServiceConfig {
     String queryValue;
 
     @JsonProperty(value = "class-name")
-    @JsonbTransient
+    @JsonIgnore
     String className;
 }

--- a/src/main/java/at/ac/tuwien/damap/rest/config/domain/ServiceConfig.java
+++ b/src/main/java/at/ac/tuwien/damap/rest/config/domain/ServiceConfig.java
@@ -1,7 +1,6 @@
 package at.ac.tuwien.damap.rest.config.domain;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -18,6 +17,5 @@ public class ServiceConfig {
     String queryValue;
 
     @JsonProperty(value = "class-name")
-    @JsonIgnore
     String className;
 }

--- a/src/main/java/at/ac/tuwien/damap/rest/persons/MockUniversityPersonServiceImpl.java
+++ b/src/main/java/at/ac/tuwien/damap/rest/persons/MockUniversityPersonServiceImpl.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import javax.inject.Named;
 
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
@@ -15,7 +14,6 @@ import at.ac.tuwien.damap.rest.dmp.domain.ContributorDO;
  */
 
 @ApplicationScoped
-@Named("UNIVERSITY")
 public class MockUniversityPersonServiceImpl implements PersonService {
 
     @Inject

--- a/src/main/java/at/ac/tuwien/damap/rest/persons/MockUniversityPersonServiceImpl.java
+++ b/src/main/java/at/ac/tuwien/damap/rest/persons/MockUniversityPersonServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
@@ -14,6 +15,7 @@ import at.ac.tuwien.damap.rest.dmp.domain.ContributorDO;
  */
 
 @ApplicationScoped
+@Named("UNIVERSITY")
 public class MockUniversityPersonServiceImpl implements PersonService {
 
     @Inject

--- a/src/main/java/at/ac/tuwien/damap/rest/persons/orcid/ContributorORCIDExpandedSearch.java
+++ b/src/main/java/at/ac/tuwien/damap/rest/persons/orcid/ContributorORCIDExpandedSearch.java
@@ -2,27 +2,26 @@ package at.ac.tuwien.damap.rest.persons.orcid;
 
 import java.util.List;
 
-import javax.json.bind.annotation.JsonbProperty;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ContributorORCIDExpandedSearch {
-    @JsonbProperty(value = "orcid-id")
+
+    @JsonProperty(value = "orcid-id")
     String orcidId;
 
-    @JsonbProperty(value = "given-names")
+    @JsonProperty(value = "given-names")
     String givenNames;
 
-    @JsonbProperty(value = "family-names")
+    @JsonProperty(value = "family-names")
     String familyNames;
 
-    @JsonbProperty(value = "email")
+    @JsonProperty(value = "email")
     List<String> emails;
 
-    @JsonbProperty(value = "institution-name")
+    @JsonProperty(value = "institution-name")
     List<String> affiliations;
 }

--- a/src/main/java/at/ac/tuwien/damap/rest/persons/orcid/ContributorORCIDExpandedSearchMapper.java
+++ b/src/main/java/at/ac/tuwien/damap/rest/persons/orcid/ContributorORCIDExpandedSearchMapper.java
@@ -17,9 +17,6 @@ public class ContributorORCIDExpandedSearchMapper {
         String firstMail = contributor.getEmails().isEmpty() ? null : contributor.getEmails().get(0);
         contributorDO.setMbox(firstMail);
 
-        // So duplicate entries in the UI are not possible
-        contributorDO.setUniversityId(contributor.orcidId);
-
         String firstAffiliation = contributor.getAffiliations().isEmpty() ? null : contributor.getAffiliations().get(0);
         contributorDO.setAffiliation(firstAffiliation);
 

--- a/src/main/java/at/ac/tuwien/damap/rest/persons/orcid/ORCIDExpandedSearchResult.java
+++ b/src/main/java/at/ac/tuwien/damap/rest/persons/orcid/ORCIDExpandedSearchResult.java
@@ -2,19 +2,17 @@ package at.ac.tuwien.damap.rest.persons.orcid;
 
 import java.util.List;
 
-import javax.json.bind.annotation.JsonbProperty;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ORCIDExpandedSearchResult {
 
-    @JsonbProperty(value = "expanded-result")
+    @JsonProperty(value = "expanded-result")
     private List<ContributorORCIDExpandedSearch> persons;
 
-    @JsonbProperty(value = "num-found")
+    @JsonProperty(value = "num-found")
     private long numFound;
 }

--- a/src/main/java/at/ac/tuwien/damap/validation/AccessValidator.java
+++ b/src/main/java/at/ac/tuwien/damap/validation/AccessValidator.java
@@ -144,11 +144,13 @@ public class AccessValidator {
 
     // Can the selected user be given access to this dmp
     // Can be overwritten if necessary
+    // current implementation allows only institutional personnel which are also contributors
     public boolean canGetAccess(AccessDO accessDO) {
         Dmp dmp = dmpRepo.findById(accessDO.getDmpId());
         List<Contributor> contributors = dmp == null ? new ArrayList<>() : dmp.getContributorList();
         // Check if new access is for a contributor
         Optional<Contributor> contributor = contributors.stream().filter(c ->
+                c.getUniversityId() != null &&
                 c.getUniversityId().equals(accessDO.getUniversityId())).findAny();
         return contributor.isPresent();
     }

--- a/src/test/java/at/ac/tuwien/damap/rest/AccessResourceTest.java
+++ b/src/test/java/at/ac/tuwien/damap/rest/AccessResourceTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.ws.rs.core.MediaType;
 
 import static io.restassured.RestAssured.given;
@@ -36,6 +37,7 @@ class AccessResourceTest {
     SecurityService securityService;
 
     @InjectMock
+    @Named("UNIVERSITY")
     PersonService personService;
 
 

--- a/src/test/java/at/ac/tuwien/damap/rest/AccessResourceTest.java
+++ b/src/test/java/at/ac/tuwien/damap/rest/AccessResourceTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.ws.rs.core.MediaType;
 
 import static io.restassured.RestAssured.given;
@@ -37,7 +36,6 @@ class AccessResourceTest {
     SecurityService securityService;
 
     @InjectMock
-    @Named("UNIVERSITY")
     PersonService personService;
 
 

--- a/src/test/java/at/ac/tuwien/damap/rest/AccessResourceTest.java
+++ b/src/test/java/at/ac/tuwien/damap/rest/AccessResourceTest.java
@@ -5,6 +5,7 @@ import at.ac.tuwien.damap.rest.access.domain.AccessDO;
 import at.ac.tuwien.damap.rest.access.service.AccessService;
 import at.ac.tuwien.damap.rest.dmp.domain.ContributorDO;
 import at.ac.tuwien.damap.rest.dmp.domain.DmpDO;
+import at.ac.tuwien.damap.rest.persons.MockUniversityPersonServiceImpl;
 import at.ac.tuwien.damap.rest.persons.PersonService;
 import at.ac.tuwien.damap.security.SecurityService;
 import at.ac.tuwien.damap.util.TestDOFactory;
@@ -36,7 +37,7 @@ class AccessResourceTest {
     SecurityService securityService;
 
     @InjectMock
-    PersonService personService;
+    MockUniversityPersonServiceImpl personService;
 
 
     DmpDO dmpDO;


### PR DESCRIPTION
bugfix

## Description
adapt access service to newly merged person service changes

#### What does this PR do?
extracts the person service list from PersonResource, in order to be used by several classes.
enforces accessService to use the university person service
small fixes to use jackson over jsonb in new pr as well

#### Dependencies
depends on https://github.com/tuwien-csd/damap-frontend/pull/82

### Checks
<!-- Adjust list as necessary -->
<!-- In case of DB changes make sure that names do not exceed 30 chars and that audit tables have been created/updated and do not contain FKs on entities. -->
- [x] Tested with Oracle/PostgreSQL
- [x] Documentation added
- [x] Successfully ran e2e tests before merge

closes GH-<!-- insert issue number -->
