### PR TITLE
Fix HibernateProxy error

### DIFF
--- a/src/main/java/at/ac/tuwien/damap/rest/gdpr/service/GdprService.java
+++ b/src/main/java/at/ac/tuwien/damap/rest/gdpr/service/GdprService.java
@@ -5,6 +5,7 @@ import at.ac.tuwien.damap.repo.GdprRepo;
 import at.ac.tuwien.damap.rest.gdpr.domain.GdprResult;
 import at.ac.tuwien.damap.rest.gdpr.domain.GdprQuery;
 import at.ac.tuwien.damap.rest.gdpr.domain.HqlQuery;
+import org.hibernate.proxy.HibernateProxy;
 import org.reflections.Reflections;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -37,6 +38,9 @@ public class GdprService {
         Reflections reflections = new Reflections(packageName);
 
         Set<Class<?>> gdprClasses = reflections.getTypesAnnotatedWith(Gdpr.class);
+
+        // Ignore HibernateProxy classes
+        gdprClasses.removeIf(HibernateProxy.class::isAssignableFrom);
 
         // Get fields containing GDPR data
         baseQueries = new ArrayList<>();


### PR DESCRIPTION
Apparently reflection retrieves the HibernateProxies for annotated classes as well, which is not what we want as we only need (and can work with) the actual classes.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
Bugfix

#### What does this PR do?
Fixes a bug introduced in ec5ccaade4acacaacaea926acca3e221e489299d.
HibernateProxy classes are now ignored, when creating the GDPR queries.

### Checks
<!-- Adjust list as necessary -->
<!-- In case of DB changes make sure that names do not exceed 30 chars and that audit tables have been created/updated and do not contain FKs on entities. -->
- [ ] Tested with Oracle/PostgreSQL
- [ ] Successfully ran e2e tests before merge

refs GH-77
