### PR TITLE
ci: add deploy to maven as step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,26 @@ permissions:
 jobs:
   maven-deploy:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Maven Central Repository
+        uses: actions/setup-java@v4.2.1
+        with:
+          distribution: "adopt"
+          java-version: 17.0
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+      - name: Publish package
+        run: mvn --batch-mode deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          DEPLOY_PROFILE: maven # same as specified in the deploy-mvn-repository profile in pom.xml
+
+  github-deploy:
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -24,7 +44,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4.2.1
         with:
-          distribution: 'adopt'
+          distribution: "adopt"
           java-version: 17.0
 
       - name: Publish to GitHub packages

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>at.ac.tuwien</groupId>
@@ -138,8 +140,8 @@
       <artifactId>quarkus-jdbc-postgresql</artifactId>
     </dependency>
     <dependency>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-jdbc-oracle</artifactId>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jdbc-oracle</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -152,8 +154,8 @@
     </dependency>
     <!-- Health -->
     <dependency>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-smallrye-health</artifactId>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-health</artifactId>
     </dependency>
     <!-- Utility -->
     <dependency>
@@ -178,8 +180,8 @@
       <version>4.1.2</version>
     </dependency>
     <dependency>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-config-yaml</artifactId>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-config-yaml</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -208,7 +210,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${compiler-plugin.version}</version>
         <configuration>
-            <parameters>${maven.compiler.parameters}</parameters>
+          <parameters>${maven.compiler.parameters}</parameters>
         </configuration>
       </plugin>
       <plugin>
@@ -297,7 +299,7 @@
                 <configuration>
                   <systemPropertyVariables>
                     <native.image.path>
-                        ${project.build.directory}/${project.build.finalName}-runner
+                      ${project.build.directory}/${project.build.finalName}-runner
                     </native.image.path>
                     <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                     <maven.home>${maven.home}</maven.home>
@@ -330,6 +332,23 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+
+    <profile>
+      <id>deploy-mvn-repository</id>
+      <activation>
+        <property>
+          <name>env.DEPLOY_PROFILE</name>
+          <value>maven</value>
+        </property>
+      </activation>
+      <distributionManagement>
+        <repository>
+          <id>ossrh</id>
+          <name>Central Repository OSSRH</name>
+          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+      </distributionManagement>
     </profile>
   </profiles>
 


### PR DESCRIPTION
config: add maven deploy profile

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
Feature

Add deploy to maven repository to ci. A profile for maven deployment is declared, as only one `distributionManagement` tag can be set and only one `repository` inside of this can be specified. Deploying to different repositories (github, maven) requires this change.

#### What does this PR do?
<!-- Changes introduced by this PR - what happened before, what happens now -->
Releases will be deployed to maven repository.

#### Breaking changes
<!-- Whether this PR contains breaking changes and which -->

#### Code review focus
<!-- What you want the reviewer to focus on -->

#### Dependencies
<!-- If this PR depends on or requires other/additional (frontend) changes, please list them here -->
An account has to be created on https://oss.sonatype.org/ and then the environment variables for the CI have to be set (`OSSRH_USERNAME` , `OSSRH_TOKEN`).

### Checks
<!-- Adjust list as necessary -->
<!-- In case of DB changes make sure that names do not exceed 30 chars and that audit tables have been created/updated and do not contain FKs on entities. -->
- [ ] Tested with Oracle/PostgreSQL
- [ ] Export updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-<!-- insert issue number -->

ref #33 
