### PR TITLE
exports: add qute template for horizon europe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>at.ac.tuwien</groupId>
@@ -119,6 +121,10 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jaxb</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-qute</artifactId>
+    </dependency>
     <!-- Authentication -->
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -138,8 +144,8 @@
       <artifactId>quarkus-jdbc-postgresql</artifactId>
     </dependency>
     <dependency>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-jdbc-oracle</artifactId>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jdbc-oracle</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -152,8 +158,8 @@
     </dependency>
     <!-- Health -->
     <dependency>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-smallrye-health</artifactId>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-health</artifactId>
     </dependency>
     <!-- Utility -->
     <dependency>
@@ -178,12 +184,17 @@
       <version>4.1.2</version>
     </dependency>
     <dependency>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-config-yaml</artifactId>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-config-yaml</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-cache</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.docx4j</groupId>
+      <artifactId>docx4j-ImportXHTML</artifactId>
+      <version>8.3.8</version>
     </dependency>
   </dependencies>
 
@@ -208,7 +219,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${compiler-plugin.version}</version>
         <configuration>
-            <parameters>${maven.compiler.parameters}</parameters>
+          <parameters>${maven.compiler.parameters}</parameters>
         </configuration>
       </plugin>
       <plugin>
@@ -297,7 +308,7 @@
                 <configuration>
                   <systemPropertyVariables>
                     <native.image.path>
-                        ${project.build.directory}/${project.build.finalName}-runner
+                      ${project.build.directory}/${project.build.finalName}-runner
                     </native.image.path>
                     <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                     <maven.home>${maven.home}</maven.home>

--- a/src/main/java/at/ac/tuwien/damap/domain/DamapRevisionEntity.java
+++ b/src/main/java/at/ac/tuwien/damap/domain/DamapRevisionEntity.java
@@ -45,4 +45,3 @@ public class DamapRevisionEntity {
     @ModifiedEntityNames
     private Set<String> modifiedEntityNames = new HashSet<>();
 }
-

--- a/src/main/java/at/ac/tuwien/damap/rest/DmpDocumentResource.java
+++ b/src/main/java/at/ac/tuwien/damap/rest/DmpDocumentResource.java
@@ -1,25 +1,43 @@
 package at.ac.tuwien.damap.rest;
 
-import at.ac.tuwien.damap.conversion.ExportTemplateBroker;
-import at.ac.tuwien.damap.enums.ETemplateType;
-import at.ac.tuwien.damap.rest.dmp.service.DmpService;
-import at.ac.tuwien.damap.security.SecurityService;
-import at.ac.tuwien.damap.validation.AccessValidator;
-import io.quarkus.security.Authenticated;
-import io.quarkus.security.AuthenticationFailedException;
-import io.quarkus.security.ForbiddenException;
-import lombok.extern.jbosslog.JBossLog;
-import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import java.io.IOException;
+import java.io.OutputStream;
 
 import javax.inject.Inject;
-import javax.ws.rs.*;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
-import java.io.*;
+// import javax.xml.bind.JAXBContext;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.docx4j.XmlUtils;
+import org.docx4j.convert.in.xhtml.XHTMLImporterImpl;
+import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
+
+import at.ac.tuwien.damap.conversion.ExportTemplateBroker;
+import at.ac.tuwien.damap.enums.ETemplateType;
+import at.ac.tuwien.damap.rest.dmp.domain.DatasetDO;
+import at.ac.tuwien.damap.rest.dmp.domain.DmpDO;
+import at.ac.tuwien.damap.rest.dmp.service.DmpService;
+import at.ac.tuwien.damap.security.SecurityService;
+import at.ac.tuwien.damap.validation.AccessValidator;
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.TemplateExtension;
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.security.AuthenticationFailedException;
+import io.quarkus.security.ForbiddenException;
+import lombok.extern.jbosslog.JBossLog;
 
 @Path("/api/document")
-@Authenticated
+// TODO: Reset before merging. Only for testing purpose.
+// @Authenticated
 @Produces(MediaType.APPLICATION_OCTET_STREAM)
 @JBossLog
 public class DmpDocumentResource {
@@ -36,13 +54,26 @@ public class DmpDocumentResource {
     @Inject
     DmpService dmpService;
 
+    @CheckedTemplate
+    public static class Templates {
+        public static native TemplateInstance horizonEurope(DmpDO dmp);
+    }
+
+    @TemplateExtension
+    public static class TemplateExtensions {
+
+        public static String datasetSize(DatasetDO ds) {
+            return FileUtils.byteCountToDisplaySize(ds.getSize());
+        }
+    }
+
     @GET
     @Path("/{dmpId}")
     public Response exportTemplate(@PathParam("dmpId") long dmpId, @QueryParam("template") ETemplateType template) {
         log.info("Return DMP document file for DMP with id=" + dmpId);
 
         String personId = this.getPersonId();
-        if(!accessValidator.canViewDmp(dmpId, personId)){
+        if (!accessValidator.canViewDmp(dmpId, personId)) {
             throw new ForbiddenException("Not authorized to access dmp with id " + dmpId);
         }
 
@@ -65,7 +96,32 @@ public class DmpDocumentResource {
 
         return Response.ok(streamingOutput)
                 .header("Content-Disposition", "attachment;filename=" + filename + ".docx")
-                .header("Access-Control-Expose-Headers","Content-Disposition")
+                .header("Access-Control-Expose-Headers", "Content-Disposition")
+                .build();
+    }
+
+    @GET
+    @Path("/{dmpId}/qute")
+    public Response qute(@PathParam("dmpId") long dmpId, @QueryParam("template") ETemplateType template)
+            throws Exception {
+        log.info("Return DMP document file for DMP with id=" + dmpId);
+
+        String filename = dmpService.getDefaultFileName(dmpId);
+        DmpDO dmp = dmpService.getDmpById(dmpId);
+
+        var templateInstance = Templates.horizonEurope(dmp);
+        var rendered = templateInstance.render();
+
+        WordprocessingMLPackage wordMLPackage = WordprocessingMLPackage.createPackage();
+        XHTMLImporterImpl XHTMLImporter = new XHTMLImporterImpl(wordMLPackage);
+
+        wordMLPackage.getMainDocumentPart().getContent().addAll(XHTMLImporter.convert(rendered, filename));
+
+        var s = XmlUtils.marshaltoString(wordMLPackage.getMainDocumentPart().getJaxbElement());
+
+        return Response.ok(rendered)
+                .header("Content-Disposition", "attachment;filename=" + filename + ".docx")
+                .header("Access-Control-Expose-Headers", "Content-Disposition")
                 .build();
     }
 

--- a/src/main/java/at/ac/tuwien/damap/rest/dmp/domain/DmpDO.java
+++ b/src/main/java/at/ac/tuwien/damap/rest/dmp/domain/DmpDO.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Valid
 @Data
@@ -93,5 +94,9 @@ public class DmpDO {
     public ContributorDO getContact(){
         Optional<ContributorDO> contact = contributors.stream().filter(ContributorDO::isContact).findFirst();
         return contact.orElse(null);
+    }
+
+    public List<DatasetDO> getProducedDatasets() {
+        return datasets.stream().filter(dataset -> dataset.getSource().equals(EDataSource.NEW)).collect(Collectors.toList());
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -71,6 +71,9 @@ quarkus:
     migrate-at-start: true
     change-log: db/changeLog.yaml
 
+  qute:
+    suffixes: [qute.html,qute.txt,html,txt,xhtml]
+
 rest:
   projects/mp-rest/url: ${damap.projects-url}
   persons/mp-rest/url: ${damap.persons-url}

--- a/src/main/resources/templates/DmpDocumentResource/horizonEurope.xhtml
+++ b/src/main/resources/templates/DmpDocumentResource/horizonEurope.xhtml
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+
+{#let projectName = (dmp.project == null ? "[Project Title]" : dmp.project.getTitle())}
+{#let contactPerson = dmp.getContact()}
+{#let contactPersonName = (contactPerson == null ? "[Contact Perseon]" : (contactPerson.firstName + " " + contactPerson.lastName)) }
+
+<html>
+
+<head>
+    <meta charset="UTF-8">
+    </meta>
+    <title>{dmp.title}</title>
+
+    <style>
+        .center-text {
+            text-align: center;
+        }
+
+
+        th {
+            color: blue;
+            border: 1px dotted #ddd;
+        }
+
+        ol {
+            counter-reset: section;
+            /* Creates a new instance of the
+                             section counter with each ol
+                             element */
+            list-style-type: none;
+            padding-left: 0;
+        }
+
+        li::before {
+            counter-increment: section;
+            /* Increments only this instance
+                                            of the section counter */
+            content: counters(section, ".") " ";
+            /* Combines the values of all instances
+                                          of the section counter, separated
+                                          by a period */
+        }
+    </style>
+
+</head>
+
+<body>
+    <h1 class="center-text">
+        {projectName}
+    </h1>
+    <h2 class="center-text">
+        {#if dmp.project != null && dmp.project.getAcronym() != null && dmp.project.getAcronym().length > 0}
+        {dmp.project.getAcronym()}
+        {#else}
+        Project Acronym
+        {/if}
+    </h2>
+    <h2 class="center-text">Data Management Plan</h2>
+
+
+    <ol>
+        <li>
+            <h2>Executive Summary</h2>
+            <ol>
+                <li>
+                    <h4>
+                        Introduction
+                    </h4>
+                    A data management plan (DMP) is a structured document that keeps record of what research data
+                    is created or reused and what happens to that data during and after a project. It helps with
+                    planning the research process and defining responsibilities in a research project involving
+                    several researchers or institutions. For writing this DMP, we followed the Horizon Europe DMP
+                    template.
+
+                    {contactPersonName} will act as the data manager who will be in charge of the actions
+                    described by this DMP.
+                </li>
+                <li>
+                    <h4>Data Summary</h4>
+
+                    <div style="border: 2px solid blue; width: 100vw;">
+                        Lorem ipsum dolor sit amet ...
+                        Lorem ipsum dolor sit amet ...
+                        Lorem ipsum dolor sit amet ...
+                        Lorem ipsum dolor sit amet ...
+                        Lorem ipsum dolor sit amet ...
+                        Lorem ipsum dolor sit amet ...
+                        Lorem ipsum dolor sit amet ...
+                    </div>
+
+                    <h4>Produced datasets</h4>
+                    <table aria-describedby="Produced Datasets">
+                        <tr>
+                            <th>Dataset ID</th>
+                            <th>Title</th>
+                            <th>Type</th>
+                            <th>Format</th>
+                            <th>Estimated Volume</th>
+                            <th>Contains Sensitive Data</th>
+                        </tr>
+                        {#for ds in dmp.getProducedDatasets()}
+                        <tr>
+                            <td>P{ds_count}</td>
+                            <td>{ds.title}</td>
+                            <td>{#for type in ds.type}{type} {/for}</td>
+                            <td></td>
+                            <td>{ds.datasetSize}</td>
+                            <td>{ds.sensitiveData ? "Yes" : "No"}</td>
+                        </tr>
+                        {/for}
+                    </table>
+
+                    <h4>Reused datasets</h4>
+                </li>
+            </ol>
+        </li>
+    </ol>
+
+</body>
+
+</html>
+
+{/let}
+{/let}
+{/let}


### PR DESCRIPTION
First try of resolving https://github.com/tuwien-csd/damap-backend/issues/114

This shows a basic implementation of

- having html template
- render with qute
- convert to to .docx for the export

As can be seen, the code required for a new template would be more concise than the current implementation. It also allows to track the changes made to the template.

The template is not complete. Converting html to .docx comes with some issues:

- Styling: Not everything supported in html will also be supported in .docx.
- Enumerations: Padding and styling is not converted correctly from html. Probably needs additional XML.
- Header/Footer per page: Requires additional XML in the template.
- Table of contents: Easy to link to certain parts/sections but getting the page number could be difficult.

