### PR TITLE
#122 - Updated the config for dev-mode

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -17,11 +17,8 @@ services:
       POSTGRES_USER: damap
       POSTGRES_PASSWORD: pw4damap
       POSTGRES_DB: damap
-
-    # Uncomment the following to directly access the database
-    # at localhost:8088
-    # ports:
-    #  - "8088:5432"
+    ports:
+      - "8088:5432"
 
   keycloak:
     image: jboss/keycloak

--- a/docker/sample-damap-realm-export.json
+++ b/docker/sample-damap-realm-export.json
@@ -702,7 +702,8 @@
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "http://localhost:8085/*"
+        "http://localhost:8085/*",
+        "http://localhost:4200/*"
       ],
       "webOrigins": [
         "+"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -85,10 +85,16 @@ rest:
 "%dev":
   damap:
     origins: http://localhost:4200
+    auth:
+      backend:
+        url: http://localhost:8087/auth/realms/damap # https://your.authentication.server
     datasource:
-      url: jdbc:postgresql://localhost:5432/damap
+      url: jdbc:postgresql://localhost:8088/damap
       username: damap
       password: pw4damap
+    projects-url: http://localhost:8091
+    persons-url: http://localhost:8091
+    fits-url: http://localhost:8089/fits
 
 "%oracle":
   quarkus:


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
Config

#### What does this PR do?
Prev dev-mode config did not override enough. Configs like `fits-url` had to be overwritten manually. Now dev-mode overrides everything it needs to. The changes assume, that the user wants to start the backend and frontend together, outside of docker. To test this, one has to uncomment this part in the docker-compose.yaml file.
```
  # Uncomment the following to directly access the database
  # at localhost:8088
    ports:
     - "8088:5432"
```

#### Code review focus
I tested this with the docker-compose file in different states.
- Nothing uncommented
- The above lines uncommented
- Everything uncommented that can be

For every state, I started the application with docker and outside of docker.
It behaved like expected at every step.
Please make sure, that it does not interfere with custom projects.

closes GH-122
