### PR TITLE
docker-services: Force pull of latest images

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
     # Since DAMAP containers are publicly available on Github packages one can
     # just pull the latest container image.
     image: ghcr.io/tuwien-csd/damap-backend:next
+    pull_policy: always
 
     # uncomment the following two lines and comment the previous
     # 'image' to directly build the backend container from this repository.
@@ -13,6 +14,7 @@ services:
 
   damap-db:
     image: postgres:12
+    pull_policy: always
     environment:
       POSTGRES_USER: damap
       POSTGRES_PASSWORD: pw4damap
@@ -22,6 +24,7 @@ services:
 
   keycloak:
     image: jboss/keycloak
+    pull_policy: always
     environment:
       KEYCLOAK_USER: admin
       KEYCLOAK_PASSWORD: admin
@@ -54,6 +57,7 @@ services:
     # Since DAMAP containers are publicly available on Github packages one can
     # just pull the latest container image.
     image: ghcr.io/tuwien-csd/damap-frontend:next
+    pull_policy: always
 
     # uncomment the following two lines and comment the previous
     # 'image' to directly build the frontend container from the repository
@@ -63,6 +67,7 @@ services:
 
   api-mock:
     image: clue/json-server
+    pull_policy: always
     command: db.json --routes routes.json
     volumes:
       - ./api-mock/data/db.json:/data/db.json
@@ -75,6 +80,7 @@ services:
     # configuration needs a proxy to manage the connections between them,
     # as well as access from the outside.
     image: registry.hub.docker.com/library/nginx
+    pull_policy: always
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf
     ports:
@@ -82,6 +88,7 @@ services:
 
   fits-service:
     image: islandora/fits:main
+    pull_policy: always
     ports:
       - "8089:8080"
 


### PR DESCRIPTION
## Description
<!-- Please select a type that best describes your PR -->
<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->

#### What does this PR do?
Forces command `docker compose up -d` to always pull the latest images, eliminating the need to specify `docker compose pull` manually.

#### Extra information
Locally I already had outdated images, e.g.:
```
$ docker images
ghcr.io/tuwien-csd/damap-frontend                   next                           30f1f890ab87   7 months ago    144MB
```
After applying the changes:
```
$ docker compose up -d
[+] Running 28/28
 ✔ damap-be 6 layers [⣿⣿⣿⣿⣿⣿]      0B/0B      Pulled                                                                                                                                                                                                                                10.6s 
   ✔ 72a2451028f1 Already exists                                                                                                                                                                                                                                                     0.0s 
   ✔ 88b00f8b035f Pull complete                                                                                                                                                                                                                                                      6.3s 
   ✔ 9c170fb7df4f Pull complete                                                                                                                                                                                                                                                      5.0s 
   ✔ f7c7e1a9e89f Pull complete                                                                                                                                                                                                                                                      9.6s 
   ✔ e2b659a659c0 Pull complete                                                                                                                                                                                                                                                      4.6s 
   ✔ f282b43f5c89 Pull complete                                                                                                                                                                                                                                                      6.6s 
 ✔ damap-fe 10 layers [⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿]      0B/0B      Pulled                                                                                                                                                                                                                            4.2s 
   ✔ 578acb154839 Already exists                                                                                                                                                                                                                                                     0.0s 
   ✔ c7c372aec845 Pull complete                                                                                                                                                                                                                                                      1.6s 
   ✔ b4d19c6dd98a Pull complete                                                                                                                                                                                                                                                      0.4s 
   ✔ 942cdad0ac45 Pull complete                                                                                                                                                                                                                                                      0.4s 
   ✔ 33d0cd853a81 Pull complete                                                                                                                                                                                                                                                      0.9s 
   ✔ 5ddf72c2853d Pull complete                                                                                                                                                                                                                                                      0.9s 
   ✔ 14d6cd9d4c81 Pull complete                                                                                                                                                                                                                                                      1.5s 
   ✔ 51284ec17435 Pull complete                                                                                                                                                                                                                                                      1.4s 
   ✔ 13d4fd7931b4 Pull complete                                                                                                                                                                                                                                                      1.9s 
   ✔ 51ecb89c41c6 Pull complete                                                                                                                                                                                                                                                      2.2s 
 ✔ api-mock Pulled                                                                                                                                                                                                                                                                   1.1s 
 ✔ proxy 7 layers [⣿⣿⣿⣿⣿⣿⣿]      0B/0B      Pulled                                                                                                                                                                                                                                   2.5s 
   ✔ 1f7ce2fa46ab Already exists                                                                                                                                                                                                                                                     0.0s 
   ✔ 9b16c94bb686 Already exists                                                                                                                                                                                                                                                     0.0s 
   ✔ 9a59d19f9c5b Already exists                                                                                                                                                                                                                                                     0.0s 
   ✔ 9ea27b074f71 Already exists                                                                                                                                                                                                                                                     0.0s 
   ✔ c6edf33e2524 Already exists                                                                                                                                                                                                                                                     0.0s 
   ✔ 84b1ff10387b Already exists                                                                                                                                                                                                                                                     0.0s 
   ✔ 517357831967 Already exists                                                                                                                                                                                                                                                     0.0s 
 ✔ keycloak Pulled                                                                                                                                                                                                                                                                   1.1s 
[+] Building 0.0s (0/0)                                                                                                                                                                                                                                                    docker:default
[+] Running 8/8
 ✔ Network docker_default           Created                                                                                                                                                                                                                                         12.3s 
 ✔ Container docker-keycloak-1      Started                                                                                                                                                                                                                                          0.2s 
 ✔ Container docker-proxy-1         Started                                                                                                                                                                                                                                          0.2s 
 ✔ Container docker-damap-fe-1      Started                                                                                                                                                                                                                                          0.2s 
 ✔ Container docker-api-mock-1      Started                                                                                                                                                                                                                                          0.2s 
 ✔ Container docker-damap-be-1      Started                                                                                                                                                                                                                                          0.2s 
 ✔ Container docker-damap-db-1      Started                                                                                                                                                                                                                                          0.2s 
 ✔ Container docker-fits-service-1  Started
```

closes GH-58
