### PR TITLE
export: Fix bug exporting AffiliationId even when null

### DIFF
--- a/src/main/java/at/ac/tuwien/damap/conversion/AbstractTemplateExportScienceEuropeComponents.java
+++ b/src/main/java/at/ac/tuwien/damap/conversion/AbstractTemplateExportScienceEuropeComponents.java
@@ -294,7 +294,7 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
             }
 
             contributorAffiliationId = getContributorAffiliationIdentifier(contributor);
-            if (contributorAffiliation != null) {
+            if (contributorAffiliationId != null) {
                 contributorProperties.add(contributorAffiliationId);
             }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
Bugfix

#### What does this PR do?
AffiliationId is now not exported into Science Europe template when null.

### Checks
<!-- Adjust list as necessary -->
<!-- In case of DB changes make sure that names do not exceed 30 chars and that audit tables have been created/updated and do not contain FKs on entities. -->
- [ ] Tested with Oracle/PostgreSQL
- [ ] Export updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-135
