### PR TITLE
DmpVersion: Add foreign key revision entity

### DIFF
--- a/src/main/java/at/ac/tuwien/damap/domain/DmpVersion.java
+++ b/src/main/java/at/ac/tuwien/damap/domain/DmpVersion.java
@@ -25,12 +25,17 @@ public class DmpVersion extends PanacheEntity {
     @EqualsAndHashCode.Exclude
     private Dmp dmp;
 
-    @Column(name = "revision_number")
-    private long revisionNumber;
-
     @Column(name = "version_date")
     private Date versionDate;
 
     @Column(name = "version_name")
     private String versionName;
+
+    @JsonIgnore
+    @OneToOne(fetch = FetchType.LAZY)
+    @EqualsAndHashCode.Exclude
+    @JoinColumn(name = "revision_entity_id")
+    private DamapRevisionEntity revisionEntity;
+
+
 }

--- a/src/main/java/at/ac/tuwien/damap/rest/version/VersionDO.java
+++ b/src/main/java/at/ac/tuwien/damap/rest/version/VersionDO.java
@@ -17,4 +17,5 @@ public class VersionDO {
     private String versionName;
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
     private Date versionDate;
+    private String editor;
 }

--- a/src/main/java/at/ac/tuwien/damap/rest/version/VersionDOMapper.java
+++ b/src/main/java/at/ac/tuwien/damap/rest/version/VersionDOMapper.java
@@ -1,8 +1,11 @@
 package at.ac.tuwien.damap.rest.version;
 
+import at.ac.tuwien.damap.domain.DamapRevisionEntity;
 import at.ac.tuwien.damap.domain.DmpVersion;
 import at.ac.tuwien.damap.repo.DmpRepo;
 import lombok.experimental.UtilityClass;
+import org.hibernate.envers.AuditReader;
+import org.hibernate.envers.AuditReaderFactory;
 
 @UtilityClass
 public class VersionDOMapper {
@@ -10,9 +13,10 @@ public class VersionDOMapper {
     public VersionDO mapEntityToDO(DmpVersion version, VersionDO versionDO) {
         versionDO.setId(version.id);
         versionDO.setDmpId(version.getDmp().id);
-        versionDO.setRevisionNumber(version.getRevisionNumber());
+        versionDO.setRevisionNumber(version.getRevisionEntity().getId());
         versionDO.setVersionName(version.getVersionName());
         versionDO.setVersionDate(version.getVersionDate());
+        versionDO.setEditor(version.getRevisionEntity().getChangedBy());
 
         return versionDO;
     }
@@ -21,11 +25,16 @@ public class VersionDOMapper {
         if (versionDO.getId() != null)
             version.id = versionDO.getId();
         version.setDmp(dmpRepo.findById(versionDO.getDmpId()));
-        if (versionDO.getRevisionNumber() != null)
-            version.setRevisionNumber(versionDO.getRevisionNumber());
-        version.setVersionName(versionDO.getVersionName());
         version.setVersionDate(versionDO.getVersionDate());
-
+        version.setVersionName(versionDO.getVersionName());
+        if (versionDO.getRevisionNumber() != null) {
+            version.setRevisionEntity(getRevisionByRevisionNumber(dmpRepo, versionDO.getRevisionNumber()));
+        }
         return version;
+    }
+
+    private DamapRevisionEntity getRevisionByRevisionNumber(DmpRepo dmpRepo, long revisionNumber) {
+        AuditReader reader = AuditReaderFactory.get(dmpRepo.getEntityManager());
+        return reader.findRevision(DamapRevisionEntity.class, revisionNumber);
     }
 }

--- a/src/main/java/at/ac/tuwien/damap/rest/version/VersionService.java
+++ b/src/main/java/at/ac/tuwien/damap/rest/version/VersionService.java
@@ -42,9 +42,9 @@ public class VersionService {
     @Transactional
     public VersionDO create(VersionDO versionDO) {
         log.info("Creating new DMP Version");
+        versionDO.setRevisionNumber(getCurrentRevisionNumber().longValue());
         DmpVersion version = VersionDOMapper.mapDOtoEntity(versionDO, new DmpVersion(), dmpRepo);
         version.setVersionDate(new Date());
-        version.setRevisionNumber(getCurrentRevisionNumber().longValue());
         version.persist();
         return getVersionById(version.id);
     }

--- a/src/main/resources/at/ac/tuwien/damap/db/changeLog-3.x/changeLog-3.0.0_1.yaml
+++ b/src/main/resources/at/ac/tuwien/damap/db/changeLog-3.x/changeLog-3.0.0_1.yaml
@@ -1,0 +1,20 @@
+databaseChangeLog:
+    - changeSet:
+        id: 9
+        author: Valentin Futterer
+        changes:
+        - renameColumn:
+            tableName: dmp_version
+            newColumnName: revision_entity_id
+            oldColumnName: revision_number
+
+        - addForeignKeyConstraint:
+            baseColumnNames: revision_entity_id
+            baseTableName: dmp_version
+            constraintName: fk_version_revision_entity
+            onDelete: SET NULL
+            onUpdate: CASCADE
+            referencedColumnNames: id
+            referencedTableName: revinfo
+            validate: true
+

--- a/src/main/resources/at/ac/tuwien/damap/db/changeLog-root.yaml
+++ b/src/main/resources/at/ac/tuwien/damap/db/changeLog-root.yaml
@@ -13,3 +13,5 @@
 databaseChangeLog:
   - include:
       file: at/ac/tuwien/damap/db/changeLog.yaml # legacy changelog
+  - include:
+      file: at/ac/tuwien/damap/db/changeLog-3.x/changeLog-3.0.0_1.yaml


### PR DESCRIPTION
Relates to issue 39 in the frontend: https://github.com/tuwien-csd/damap-frontend/issues/39

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
Feature

#### What does this PR do?
Introduces a revision entity foreign key contraint to Dmpversion. Before just the revision entity id was stored in the DmpVersion. Sorting the list is not necessary, since it already is sorted correctly.

#### Breaking changes
Adapted DmpVersion entity + added liquibase changeset.

#### Code review focus
Please check if the liquibase changeset wont break anything in production.
In VersionDOMapper - getRevisionByRevisionNumber(), should we catch RevisionDoesNotExistException or do we assume that the frontend sends correct information always

#### Dependencies
An older frontend still works with these changes, so no.

### Checks
<!-- Adjust list as necessary -->
<!-- In case of DB changes make sure that names do not exceed 30 chars and that audit tables have been created/updated and do not contain FKs on entities. -->
- [ ] Tested with Oracle/PostgreSQL
- [ ] Export updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-50
