### PR TITLE
Export: Delete delete/reused datasets tables when empty

### DIFF
--- a/src/main/java/at/ac/tuwien/damap/conversion/ExportFWFTemplate.java
+++ b/src/main/java/at/ac/tuwien/damap/conversion/ExportFWFTemplate.java
@@ -38,7 +38,7 @@ public class ExportFWFTemplate extends AbstractTemplateExportScienceEuropeCompon
         //in FWF template this replaces paragraphs within the template table
         replaceTableVariables(templateTable, replacements);
         //this replaces the tables with the main template table
-        tableContent(templateXwpfTables);
+        tableContent(document, templateXwpfTables);
 
         return document;
     }
@@ -46,7 +46,7 @@ public class ExportFWFTemplate extends AbstractTemplateExportScienceEuropeCompon
     private List<XWPFTable> parseContentTables(XWPFTable templateTable) {
         List<XWPFTable> templateXwpfTables = new ArrayList<>();
         for (XWPFTableRow row : templateTable.getRows()){
-            if (row.getTableCells().size() > 1){
+            if (row.getTableCells().size() > 1) {
                 templateXwpfTables.addAll(row.getCell(1).getTables());
             }
         }

--- a/src/main/java/at/ac/tuwien/damap/conversion/ExportHorizonEuropeTemplate.java
+++ b/src/main/java/at/ac/tuwien/damap/conversion/ExportHorizonEuropeTemplate.java
@@ -51,7 +51,7 @@ public class ExportHorizonEuropeTemplate extends AbstractTemplateExportScienceEu
         // TO DO: combine the function with the first row generation to avoid double
         // code of similar modification.
         log.debug("Export steps: Replace in table");
-        tableContent(xwpfTables);
+        tableContent(document, xwpfTables);
 
         // Fourth step of the export: modify the content of the document's footer
         log.debug("Export steps: Replace in footer");

--- a/src/main/java/at/ac/tuwien/damap/conversion/ExportScienceEuropeTemplate.java
+++ b/src/main/java/at/ac/tuwien/damap/conversion/ExportScienceEuropeTemplate.java
@@ -38,7 +38,7 @@ public class ExportScienceEuropeTemplate extends AbstractTemplateExportScienceEu
         //Third step of the export: dynamic table in all sections will be added from row number two until the end of data list.
         //TO DO: combine the function with the first row generation to avoid double code of similar modification.
         log.debug("Export steps: Replace in table");
-        tableContent(xwpfTables);
+        tableContent(document, xwpfTables);
 
         //Fourth step of the export: modify the content of the document's footer
         log.debug("Export steps: Replace in footer");


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
Bugfix

#### What does this PR do?
The reused dataset and dataset delete tables are now removed when there is no data for them.

### Checks
<!-- Adjust list as necessary -->
<!-- In case of DB changes make sure that names do not exceed 30 chars and that audit tables have been created/updated and do not contain FKs on entities. -->
- [ ] Tested with Oracle/PostgreSQL
- [x] Export updated
- [x] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-132
