### PR TITLE
Export: Correctly replace date placeholders

### DIFF
--- a/src/main/java/at/ac/tuwien/damap/conversion/AbstractTemplateExportScienceEuropeComponents.java
+++ b/src/main/java/at/ac/tuwien/damap/conversion/AbstractTemplateExportScienceEuropeComponents.java
@@ -103,10 +103,8 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
         }
 
         // variable project start date and end date
-        if (project.getStart() != null)
-            addReplacement(replacements, "[startdate]", formatter.format(project.getStart()));
-        if (project.getEnd() != null)
-            addReplacement(replacements, "[enddate]", formatter.format(project.getEnd()));
+        addReplacement(replacements, "[startdate]", project.getStart() == null ? "" : formatter.format(project.getStart()));
+        addReplacement(replacements, "[enddate]", project.getStart() == null ? "" : formatter.format(project.getEnd()));
 
 
         // add funding program to funding item variables


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
Bugfix

#### What does this PR do?
In the Science Europe template, the [startdate] and [enddate] placeholders are now correctly replaced with "", if no dateswhere given. Before. the placeholders just remained in the word document.

### Checks
<!-- Adjust list as necessary -->
<!-- In case of DB changes make sure that names do not exceed 30 chars and that audit tables have been created/updated and do not contain FKs on entities. -->
- [ ] Tested with Oracle/PostgreSQL
- [ ] Export updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-139
