### PR TITLE
Deployment enhancements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,4 @@ EXPOSE 8080
 # for Openshift based unprivilegued Kubernetes environments, we will set the user to 1001
 USER 1001
 
-HEALTHCHECK --interval=5m --timeout=3s \
-  CMD curl -f http://localhost/q/health/live || exit 1
-
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -6,25 +6,43 @@ services:
     # just pull the latest container image.
     image: ghcr.io/tuwien-csd/damap-backend:next
     pull_policy: always
+    restart: unless-stopped
 
     # uncomment the following two lines and comment the previous
     # 'image' to directly build the backend container from this repository.
     # build:
     #  context: ../
+    depends_on:
+      - damap-db
+      - keycloak
+      - api-mock
+      - fits-service
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/q/health/live"]
+      interval: 30s
+      timeout: 15s
+      retries: 5
 
   damap-db:
     image: postgres:12
     pull_policy: always
+    restart: unless-stopped
     environment:
       POSTGRES_USER: damap
       POSTGRES_PASSWORD: pw4damap
       POSTGRES_DB: damap
     ports:
       - "8088:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "sh -c 'pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}'"]
+      interval: 30s
+      timeout: 15s
+      retries: 5
 
   keycloak:
     image: jboss/keycloak
     pull_policy: always
+    restart: unless-stopped
     environment:
       KEYCLOAK_USER: admin
       KEYCLOAK_PASSWORD: admin
@@ -58,16 +76,20 @@ services:
     # just pull the latest container image.
     image: ghcr.io/tuwien-csd/damap-frontend:next
     pull_policy: always
+    restart: unless-stopped
 
     # uncomment the following two lines and comment the previous
     # 'image' to directly build the frontend container from the repository
     # assumed to be checked-out beside the 'damap-backend' repository.
     # build:
       # context: ../../damap-frontend
+    depends_on:
+      - damap-be
 
   api-mock:
     image: clue/json-server
     pull_policy: always
+    restart: unless-stopped
     command: db.json --routes routes.json
     volumes:
       - ./api-mock/data/db.json:/data/db.json
@@ -81,14 +103,19 @@ services:
     # as well as access from the outside.
     image: registry.hub.docker.com/library/nginx
     pull_policy: always
+    restart: unless-stopped
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf
     ports:
       - "8085:80"
+    depends_on:
+      - damap-fe
+      - damap-be
 
   fits-service:
     image: islandora/fits:main
     pull_policy: always
+    restart: unless-stopped
     ports:
       - "8089:8080"
 


### PR DESCRIPTION
#### What does this PR do?
* Adds start dependencies between the services (see below).
* Adds healthcheck for damap-backend (fixed previous one) and Postgres.
* Sets auto restart policy unless explicitly stopped (this would help specifically when deploying to a live server so that we don't have to restart the services ourselves on every potential reboot).

#### Problems addressed
* Previously, the damap-backend was crashing because it was starting earlier than the Postgres database. To make the whole stack work properly, one had to first start manually Postgres and then the other services.


