### PR TITLE
Export: Changed how new lines are handled when replacing

### DIFF
--- a/src/main/java/at/ac/tuwien/damap/conversion/AbstractTemplateExportFunctions.java
+++ b/src/main/java/at/ac/tuwien/damap/conversion/AbstractTemplateExportFunctions.java
@@ -66,14 +66,14 @@ public abstract class AbstractTemplateExportFunctions {
                                 xwpfParagraph.setAlignment(ParagraphAlignment.LEFT);
                                 xwpfRun.setText(value[i].trim());
                                 if (i < value.length - 1) {
-                                    xwpfRun.addCarriageReturn();
-                                    xwpfRun.addCarriageReturn();
+                                    xwpfRun.addBreak();
+                                    xwpfRun.addBreak();
                                 }
                             }
-                            // TODO: when xwpfRun.removeCarriageReturn is implemented:
+                            // TODO: when xwpfRun.removeBreak is implemented:
                             //  replace the above for loop with an enhanced one
                             //  remove the extra if inside the loop
-                            //  call removeCarriageReturn twice outside the loop
+                            //  call removeBreak twice outside the loop
                             xwpfRunText = "";
                         }
                         //general case for non contributor list


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
Bugfix

#### What does this PR do?
New lines when replacing placeholders are now again handled with breaks and not with carriage returns. the carriage returns are more user friendly, but cause weird behaviour when no other paragraph is below them. This can be fixed in the future with https://github.com/tuwien-csd/damap-backend/issues/147 .

### Checks
<!-- Adjust list as necessary -->
<!-- In case of DB changes make sure that names do not exceed 30 chars and that audit tables have been created/updated and do not contain FKs on entities. -->
- [ ] Tested with Oracle/PostgreSQL
- [ ] Export updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-157
