### PR TITLE
Service: Fixed bug where repos are not removed when updating

### DIFF
--- a/src/main/java/at/ac/tuwien/damap/rest/dmp/mapper/DmpDOMapper.java
+++ b/src/main/java/at/ac/tuwien/damap/rest/dmp/mapper/DmpDOMapper.java
@@ -13,7 +13,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 
 @UtilityClass
 @JBossLog
@@ -326,6 +325,8 @@ public class DmpDOMapper {
             }
 
         });
+
+        hostList.removeAll(hostListToRemove);
 
         // update existing Repository objects and create new ones
         dmpDO.getRepositories().forEach(hostDO -> {

--- a/src/test/java/at/ac/tuwien/damap/rest/dmp/DmpServiceTest.java
+++ b/src/test/java/at/ac/tuwien/damap/rest/dmp/DmpServiceTest.java
@@ -4,10 +4,14 @@ import at.ac.tuwien.damap.enums.EContributorRole;
 import at.ac.tuwien.damap.rest.dmp.domain.ContributorDO;
 import at.ac.tuwien.damap.rest.dmp.domain.DmpDO;
 import at.ac.tuwien.damap.rest.dmp.domain.ProjectDO;
+import at.ac.tuwien.damap.rest.dmp.domain.RepositoryDO;
 import at.ac.tuwien.damap.util.MockDmpService;
 import at.ac.tuwien.damap.util.TestDOFactory;
 import io.quarkus.test.junit.QuarkusTest;
+
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import javax.inject.Inject;
 import org.junit.jupiter.api.Assertions;
@@ -115,5 +119,30 @@ class DmpServiceTest {
         Assertions.assertTrue(projectLead.get().isContact());
         Assertions.assertEquals(
             EContributorRole.PROJECT_LEADER, projectLead.get().getRole());
+    }
+
+    @Test
+    void givenRepositoryIsRemoved_whenUpdatingDMP_thenRepositoryShouldBeRemoved() {
+        DmpDO testDMP = testDOFactory.getOrCreateTestDmpDO();
+        Assertions.assertEquals(1, testDMP.getRepositories().size());
+        testDMP.setRepositories(new ArrayList<>());
+        DmpDO updatedDMP = dmpService.update(testDMP);
+        Assertions.assertEquals(0, updatedDMP.getRepositories().size());
+    }
+
+    @Test
+    void givenRepositoryIsAdded_whenUpdatingDMP_thenRepositoryShouldBeAdded() {
+        DmpDO testDMP = testDOFactory.getOrCreateTestDmpDO();
+        Assertions.assertEquals(1, testDMP.getRepositories().size());
+
+        List<RepositoryDO> repoList = testDMP.getRepositories();
+        RepositoryDO repositoryToAdd = new RepositoryDO();
+        repositoryToAdd.setRepositoryId("r3d100013558");
+        repositoryToAdd.setTitle("TU Data 2");
+        repositoryToAdd.setDatasets(List.of("referenceHash123456", "referenceHash234567"));
+        repoList.add(repositoryToAdd);
+
+        DmpDO updatedDMP = dmpService.update(testDMP);
+        Assertions.assertEquals(2, updatedDMP.getRepositories().size());
     }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
Bugfix

#### What does this PR do?
Reintroduces the line `hostList.removeAll(hostListToRemove);` which was mistakenly removed - this fixes the issue of repos not getting removed.

### Checks
<!-- Adjust list as necessary -->
<!-- In case of DB changes make sure that names do not exceed 30 chars and that audit tables have been created/updated and do not contain FKs on entities. -->
- [ ] Tested with Oracle/PostgreSQL
- [ ] Export updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-161
