### PR TITLE
Service: Fix bug where contributor email disappears

### DIFF
--- a/src/main/java/at/ac/tuwien/damap/rest/dmp/mapper/ContributorDOMapper.java
+++ b/src/main/java/at/ac/tuwien/damap/rest/dmp/mapper/ContributorDOMapper.java
@@ -62,6 +62,7 @@ public class ContributorDOMapper {
             contributor.setAffiliationId(affiliationIdentifier);
         } else
             contributor.setAffiliationId(null);
+
         contributor.setContact(contributorDO.isContact());
         contributor.setContributorRole(contributorDO.getRole());
 

--- a/src/main/java/at/ac/tuwien/damap/rest/dmp/service/DmpService.java
+++ b/src/main/java/at/ac/tuwien/damap/rest/dmp/service/DmpService.java
@@ -12,6 +12,8 @@ import javax.inject.Inject;
 import javax.transaction.Transactional;
 import javax.validation.Valid;
 
+import at.ac.tuwien.damap.domain.Identifier;
+import at.ac.tuwien.damap.rest.dmp.mapper.*;
 import org.hibernate.envers.AuditReader;
 import org.hibernate.envers.AuditReaderFactory;
 
@@ -28,11 +30,6 @@ import at.ac.tuwien.damap.rest.dmp.domain.DmpDO;
 import at.ac.tuwien.damap.rest.dmp.domain.DmpListItemDO;
 import at.ac.tuwien.damap.rest.dmp.domain.IdentifierDO;
 import at.ac.tuwien.damap.rest.dmp.domain.ProjectDO;
-import at.ac.tuwien.damap.rest.dmp.mapper.ContributorDOMapper;
-import at.ac.tuwien.damap.rest.dmp.mapper.DmpDOMapper;
-import at.ac.tuwien.damap.rest.dmp.mapper.DmpListItemDOMapper;
-import at.ac.tuwien.damap.rest.dmp.mapper.MapperService;
-import at.ac.tuwien.damap.rest.dmp.mapper.ProjectSupplementDOMapper;
 import at.ac.tuwien.damap.rest.persons.orcid.ORCIDPersonServiceImpl;
 import at.ac.tuwien.damap.rest.projects.ProjectService;
 import at.ac.tuwien.damap.rest.projects.ProjectSupplementDO;
@@ -206,7 +203,7 @@ public class DmpService {
      * Set the project leader as contact, if there is no other contact selected.
      * Add the project leader as a contributor, if it is not already added.
      *
-     * @param Dmp Data management plan
+     * @param dmp Data management plan
      */
     private void updateProjectLead(Dmp dmp) {
         if (dmp.getProject() == null || dmp.getProject().getUniversityId() == null)
@@ -256,7 +253,19 @@ public class DmpService {
             if (identifier != null
                     && identifier.getIdentifierType().equals(EIdentifierType.ORCID)) {
                 try {
-                    ContributorDOMapper.mapDOtoEntity(orcidPersonService.read(identifier.getIdentifier()), contributor);
+                    ContributorDO contributorDO = orcidPersonService.read(identifier.getIdentifier());
+                    if (contributor.getMbox() == null || contributor.getMbox().isEmpty())
+                        contributor.setMbox(contributorDO.getMbox());
+
+                    if (contributor.getAffiliation() == null || contributor.getAffiliation().isEmpty())
+                        contributor.setAffiliation(contributorDO.getAffiliation());
+
+                    if (contributor.getFirstName() == null || contributor.getFirstName().isEmpty())
+                        contributor.setFirstName(contributorDO.getFirstName());
+
+                    if (contributor.getLastName() == null || contributor.getLastName().isEmpty())
+                        contributor.setLastName(contributorDO.getLastName());
+
                 } catch (Exception e) {
                     log.warn(String.format(
                             "Could not fetch ORCID or map contributor info for identifier '%s'.%nDetail error message: %s",

--- a/src/test/java/at/ac/tuwien/damap/rest/dmp/DmpServiceTest.java
+++ b/src/test/java/at/ac/tuwien/damap/rest/dmp/DmpServiceTest.java
@@ -154,8 +154,11 @@ class DmpServiceTest extends TestSetup {
         dmpDO = dmpService.create(dmpDO, "");
         var contributorDOs = dmpDO.getContributors();
         Assertions.assertFalse(contributorDOs.isEmpty());
-        Assertions.assertEquals(testRecord.getPerson().getName().getPath(),
-                contributorDOs.get(0).getPersonId().getIdentifier());
+        Assertions.assertEquals(testRecord.getPerson().getName().getGivenNames().getValue(),
+                contributorDOs.get(0).getFirstName());
+
+        Assertions.assertEquals(testRecord.getPerson().getName().getFamilyName().getValue(),
+                contributorDOs.get(0).getLastName());
 
     }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
Bugfix

#### What does this PR do?
https://github.com/tuwien-csd/damap-backend/pull/128 introduced the fetching of ORCID-emails on Contributor create or update. The fetched email was alaways used instead of the current one, leading to it being overwritten - most likely with null.
Now the ORCID email is only used when no other email is present (this leads to ORCID email updates not being picked up by the tool, but this should not be a big problem in my opinion).

### Checks
<!-- Adjust list as necessary -->
<!-- In case of DB changes make sure that names do not exceed 30 chars and that audit tables have been created/updated and do not contain FKs on entities. -->
- [ ] Tested with Oracle/PostgreSQL
- [ ] Export updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-178
