### PR TITLE
Export: Remove publication date when dataset is closed

### DIFF
--- a/src/main/java/at/ac/tuwien/damap/conversion/AbstractTemplateExportScienceEuropeComponents.java
+++ b/src/main/java/at/ac/tuwien/damap/conversion/AbstractTemplateExportScienceEuropeComponents.java
@@ -931,7 +931,7 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
         log.debug("Export steps: Data Publication Table");
 
         List<Dataset> newDatasets = getNewDatasets();
-        if (newDatasets.size() > 0) {
+        if (!newDatasets.isEmpty()) {
             for (int i = 0; i < newDatasets.size(); i++) {
 
                 XWPFTableRow sourceTableRow = xwpfTable.getRow(i + 2);
@@ -967,7 +967,9 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
                     docVar.add("");
                 }
 
-                if (newDatasets.get(i).getStart() != null) {
+                if (newDatasets.get(i).getDataAccess() == EDataAccessType.CLOSED) {
+                    docVar.add("");
+                } else if (newDatasets.get(i).getStart() != null) {
                     docVar.add(formatter.format(newDatasets.get(i).getStart()));
                 }
                 else {
@@ -983,13 +985,13 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
                 if (newDatasets.get(i).getDistributionList() != null){
                     List<Distribution> distributions = newDatasets.get(i).getDistributionList();
                     List<String> repositories = new ArrayList<>();
-                    if (distributions.size() > 0) {
+                    if (!distributions.isEmpty()) {
                         for (Distribution distribution: distributions) {
                             if (Repository.class.isAssignableFrom(distribution.getHost().getClass()))
                                 repositories.add(distribution.getHost().getTitle());
                         }
                     }
-                    if (repositories.size() > 0) {
+                    if (!repositories.isEmpty()) {
                         docVar.add(String.join(", ", repositories));
                     }
                     else {

--- a/src/main/java/at/ac/tuwien/damap/rest/dmp/mapper/DatasetDOMapper.java
+++ b/src/main/java/at/ac/tuwien/damap/rest/dmp/mapper/DatasetDOMapper.java
@@ -2,6 +2,7 @@ package at.ac.tuwien.damap.rest.dmp.mapper;
 
 import at.ac.tuwien.damap.domain.Dataset;
 import at.ac.tuwien.damap.domain.Identifier;
+import at.ac.tuwien.damap.enums.EDataAccessType;
 import at.ac.tuwien.damap.enums.EDataType;
 import at.ac.tuwien.damap.rest.dmp.domain.ContributorDO;
 import at.ac.tuwien.damap.rest.dmp.domain.DatasetDO;
@@ -64,7 +65,11 @@ public class DatasetDOMapper {
         dataset.setSensitiveData(datasetDO.getSensitiveData());
         dataset.setLegalRestrictions(datasetDO.getLegalRestrictions());
         dataset.setLicense(datasetDO.getLicense());
-        dataset.setStart(datasetDO.getStartDate());
+        if (datasetDO.getDataAccess() == EDataAccessType.CLOSED) {
+            dataset.setStart(null);
+        } else {
+            dataset.setStart(datasetDO.getStartDate());
+        }
         dataset.setReferenceHash(datasetDO.getReferenceHash());
         dataset.setDataAccess(datasetDO.getDataAccess());
         dataset.setSelectedProjectMembersAccess(datasetDO.getSelectedProjectMembersAccess());


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
Bugfix

#### What does this PR do?
Checks if a dataset if closed, if yes then it does not put any date in the estimated publication date column.
Also sets the publication date to null if a dmp is closed.
Related to https://github.com/tuwien-csd/damap-frontend/pull/222

### Checks
<!-- Adjust list as necessary -->
<!-- In case of DB changes make sure that names do not exceed 30 chars and that audit tables have been created/updated and do not contain FKs on entities. -->
- [ ] Tested with Oracle/PostgreSQL
- [ ] Export updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-194
