### PR TITLE
Export: Add PID information to reused datasets table

### DIFF
--- a/src/main/java/at/ac/tuwien/damap/conversion/AbstractTemplateExportFunctions.java
+++ b/src/main/java/at/ac/tuwien/damap/conversion/AbstractTemplateExportFunctions.java
@@ -208,24 +208,18 @@ public abstract class AbstractTemplateExportFunctions {
      * @param variableList
      * @return
      */
-    public String multipleVariable(List<String> variableList) {
-        switch (variableList.size()) {
-            case 0:
-                return "";
-            default:
-                return String.join(", ", variableList);
-        }
+    public String joinWithComma (List<String> variableList) {
+        return String.join(", ", variableList);
     }
 
-    public String multipleVariableAnd(List<String> variableList) {
-        switch (variableList.size()) {
-            case 0:
-                return "";
-            case 1:
-                return variableList.get(0);
-            default:
-                return String.join(", ", variableList.subList(0, (variableList.size() - 1))) + ", and " + variableList.get(variableList.size() - 1);
-        }
+    public String joinWithCommaAnd(List<String> variableList) {
+        return switch (variableList.size()) {
+            case 0 -> "";
+            case 1 -> variableList.get(0);
+            default ->
+                    String.join(", ", variableList.subList(0, (variableList.size() - 1))) + " and "
+                            + variableList.get(variableList.size() - 1);
+        };
     }
 
     /**

--- a/src/main/java/at/ac/tuwien/damap/conversion/AbstractTemplateExportScienceEuropeComponents.java
+++ b/src/main/java/at/ac/tuwien/damap/conversion/AbstractTemplateExportScienceEuropeComponents.java
@@ -154,7 +154,7 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
         String contactAffiliationId = "";
 
         if (contact == null) {
-            addReplacement(replacements, "[contact]", multipleVariable(contactItems));
+            addReplacement(replacements, "[contact]", joinWithComma(contactItems));
             return;
         }
 
@@ -184,7 +184,7 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
             contactItems.add(contactAffiliationId);
         }
 
-        addReplacement(replacements, "[contact]", multipleVariable(contactItems));
+        addReplacement(replacements, "[contact]", joinWithComma(contactItems));
     }
 
     private void projectCoordinatorInformation() {
@@ -194,7 +194,7 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
         String coordinatorAffiliationIdentifierId = "";
         
         if (projectCoordinator == null) {
-            addReplacement(replacements, "[coordinator]", multipleVariable(coordinatorProperties));
+            addReplacement(replacements, "[coordinator]", joinWithComma(coordinatorProperties));
             return;
         }
 
@@ -227,7 +227,7 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
             }
         }
 
-        addReplacement(replacements, "[coordinator]", multipleVariable(coordinatorProperties));
+        addReplacement(replacements, "[coordinator]", joinWithComma(coordinatorProperties));
     }
 
     private void dmpContributorInformation() {
@@ -279,7 +279,7 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
                 contributorProperties.add(contributorRole);
             }
 
-            contributorPerson = multipleVariable(contributorProperties);
+            contributorPerson = joinWithComma(contributorProperties);
             contributorList.add(contributorPerson);
         }
         
@@ -295,19 +295,12 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
     }
 
     public void costInformation(){
-        String costs = "";
-        if (dmp.getCostsExist() != null) {
-            if (dmp.getCostsExist().booleanValue()) {
-                costs = loadResourceService.loadVariableFromResource(prop, "costs.avail");
-            }
-            else {
-                costs = loadResourceService.loadVariableFromResource(prop, "costs.no");
-            }
+        if (Boolean.TRUE.equals(dmp.getCostsExist())) {
+            addReplacement(replacements, "[costs]", loadResourceService.loadVariableFromResource(prop, "costs.avail"));
         }
         else {
-            costs = loadResourceService.loadVariableFromResource(prop, "costs.no");
+            addReplacement(replacements, "[costs]", loadResourceService.loadVariableFromResource(prop, "costs.no"));
         }
-        addReplacement(replacements, "[costs]", costs);
     }
 
     public void datasetsInformation(){
@@ -339,16 +332,16 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
             }
 
             if (Storage.class.isAssignableFrom(host.getClass())) { //only write information related to the storage, repository will be written in section 5
-                if (!distVar.toString().equals("")) {
+                if (!distVar.toString().isEmpty()) {
                     String storageDescription = "";
                     storageDescription = internalStorageTranslationRepo.getInternalStorageById(((Storage) host).getInternalStorageId().id, "eng").getDescription();
                     storageVar = storageVar.concat(distVar + " " + loadResourceService.loadVariableFromResource(prop, "distributionStorage") + " " + hostVar + ": " + storageDescription);
                 }
             }
             else if (ExternalStorage.class.isAssignableFrom(host.getClass())) { //case for external storage, will have null host Id
-                if (!distVar.toString().equals("")) {
+                if (!distVar.toString().isEmpty()) {
                     storageVar = storageVar.concat(distVar + " " + loadResourceService.loadVariableFromResource(prop,"distributionStorage") + " " + hostVar + ".");
-                    if (dmp.getExternalStorageInfo() != null && !dmp.getExternalStorageInfo().equals("")) {
+                    if (dmp.getExternalStorageInfo() != null && !dmp.getExternalStorageInfo().isEmpty()) {
                         storageVar = storageVar.concat(" " + loadResourceService.loadVariableFromResource(prop,"distributionExternal") + " " + dmp.getExternalStorageInfo().toLowerCase());
                     }
                 }
@@ -370,7 +363,7 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
             addReplacement(replacements, "[metadata]", loadResourceService.loadVariableFromResource(prop, "metadata.no"));
         }
         else {
-            if (dmp.getMetadata().equals("")) {
+            if (dmp.getMetadata().isEmpty()) {
                 addReplacement(replacements,"[metadata]", loadResourceService.loadVariableFromResource(prop, "metadata.no"));
             }
             else {
@@ -386,7 +379,7 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
             addReplacement(replacements,"[dataorganisation]", loadResourceService.loadVariableFromResource(prop, "dataOrganisation.no"));
         }
         else {
-            if (dmp.getStructure().equals("")) {
+            if (dmp.getStructure().isEmpty()) {
                 addReplacement(replacements,"[dataorganisation]", loadResourceService.loadVariableFromResource(prop, "dataOrganisation.no"));
             }
             else {
@@ -406,7 +399,7 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
                 else
                     dataQualityList.add(dmp.getDataQuality().get(i).toString());
             }
-            dataQuality.append(" ").append(multipleVariableAnd(dataQualityList)).append(".");
+            dataQuality.append(" ").append(joinWithCommaAnd(dataQualityList)).append(".");
             addReplacement(replacements,"[dataqualitycontrol]", dataQuality.toString());
         } else {
             addReplacement(replacements,"[dataqualitycontrol]", loadResourceService.loadVariableFromResource(prop, "dataQualityControl.default"));
@@ -434,7 +427,7 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
 
             if (!sensitiveDatasetList.isEmpty()) {
                 datasetSentence = " " + loadResourceService.loadVariableFromResource(prop,"sensitive.avail.data") + " ";
-                sensitiveDataset = multipleVariableAnd(sensitiveDatasetList) + ". ";
+                sensitiveDataset = joinWithCommaAnd(sensitiveDatasetList) + ". ";
             }
             else {
                 datasetSentence = ". ";
@@ -459,9 +452,9 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
             else {
                 //security measurement size defined is/or usage
                 if (dataSecurityList.size() == 1) {
-                    sensitiveDataMeasure = loadResourceService.loadVariableFromResource(prop,"sensitiveMeasure.avail") + " " + multipleVariableAnd(dataSecurityList) + " " + loadResourceService.loadVariableFromResource(prop,"sensitiveMeasure.singular");
+                    sensitiveDataMeasure = loadResourceService.loadVariableFromResource(prop,"sensitiveMeasure.avail") + " " + joinWithCommaAnd(dataSecurityList) + " " + loadResourceService.loadVariableFromResource(prop,"sensitiveMeasure.singular");
                 } else {
-                    sensitiveDataMeasure = loadResourceService.loadVariableFromResource(prop,"sensitiveMeasure.avail") + " " + multipleVariableAnd(dataSecurityList) + " " + loadResourceService.loadVariableFromResource(prop,"sensitiveMeasure.multiple");
+                    sensitiveDataMeasure = loadResourceService.loadVariableFromResource(prop,"sensitiveMeasure.avail") + " " + joinWithCommaAnd(dataSecurityList) + " " + loadResourceService.loadVariableFromResource(prop,"sensitiveMeasure.multiple");
                 }
             }
 
@@ -483,13 +476,7 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
         List<String> repoTexts = new ArrayList<>();
 
         for (Dataset dataset : datasets) {
-            List<Distribution> distributions = dataset.getDistributionList();
-            for (Distribution distribution : distributions) {
-                Host host = distribution.getHost();
-                if (Repository.class.isAssignableFrom(host.getClass())) {
-                    repositories.add((Repository) distribution.getHost());
-                }
-            }
+            repositories.addAll(dataset.getRepositories());
         }
 
         if (!repositories.isEmpty()) {
@@ -502,7 +489,7 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
             repoInformation = String.join("; ", repoTexts);
         }
 
-        addReplacement(replacements, "[repoinformation]", repoInformation + (repoInformation.equals("") ? "" : ";"));
+        addReplacement(replacements, "[repoinformation]", repoInformation + (repoInformation.isEmpty() ? "" : ";"));
     }
 
     public void repoinfoAndToolsInformation() {
@@ -554,7 +541,7 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
             }
             //add dataset list if available
             if (!personalDatasetList.isEmpty()) {
-                personalData += multipleVariableAnd(personalDatasetList);
+                personalData += joinWithCommaAnd(personalDatasetList);
                 personalData += " " + loadResourceService.loadVariableFromResource(prop, "personalDataset") + " ";
             }
 
@@ -569,7 +556,7 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
                         dataComplianceList.add(personalCompliance.toString());
                 }
                 personalData += loadResourceService.loadVariableFromResource(prop, "personalCompliance") + " ";
-                personalData += multipleVariableAnd(dataComplianceList) + ".";
+                personalData += joinWithCommaAnd(dataComplianceList) + ".";
             }
         } else {
             personalData = loadResourceService.loadVariableFromResource(prop, "personal.no");
@@ -597,7 +584,7 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
                     else
                         agreementList.add(agreement.toString());
                 }
-                legalRestrictionText += multipleVariableAnd(agreementList) + ". ";
+                legalRestrictionText += joinWithCommaAnd(agreementList) + ". ";
             } else {
                 legalRestrictionText = loadResourceService.loadVariableFromResource(prop, "legal.avail.default") + " ";
             }
@@ -611,7 +598,7 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
             }
             if (!datasetList.isEmpty()) {
                 legalRestrictionText += loadResourceService.loadVariableFromResource(prop, "legalDataset") + " ";
-                legalRestrictionText += multipleVariableAnd(datasetList) +". ";
+                legalRestrictionText += joinWithCommaAnd(datasetList) +". ";
             }
 
             //add legal restrictions comment if available
@@ -739,7 +726,7 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
         log.debug("Export steps: New Dataset Table");
 
         List<Dataset> newDatasets = getNewDatasets();
-        if (newDatasets.size() > 0) {
+        if (!newDatasets.isEmpty()) {
             for (int i = 0; i < newDatasets.size(); i++) {
 
                 XWPFTableRow sourceTableRow = xwpfTable.getRow(2);
@@ -801,18 +788,18 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
     }
 
     public List<Dataset> getNewDatasets(){
-        return datasets.stream().filter(dataset -> dataset.getSource().equals(EDataSource.NEW)).collect(Collectors.toList());
+        return datasets.stream().filter(dataset -> dataset.getSource().equals(EDataSource.NEW)).toList();
     }
 
     public List<Dataset> getReusedDatasets(){
-        return datasets.stream().filter(dataset -> dataset.getSource().equals(EDataSource.REUSED)).collect(Collectors.toList());
+        return datasets.stream().filter(dataset -> dataset.getSource().equals(EDataSource.REUSED)).toList();
     }
 
     public void composeTableReusedDatasets(XWPFDocument document, XWPFTable xwpfTable){
         log.debug("Export steps: Reused Dataset Table");
 
         List<Dataset> reusedDatasets = getReusedDatasets();
-        if (reusedDatasets.size() > 0) {
+        if (!reusedDatasets.isEmpty()) {
             for (int i = 0; i < reusedDatasets.size(); i++) {
 
                 XWPFTableRow sourceTableRow = xwpfTable.getRow(2);
@@ -873,7 +860,7 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
 
         List<Dataset> newDatasets = getNewDatasets();
         List<Dataset> reusedDatasets = getReusedDatasets();
-        if (datasets.size() > 0) {
+        if (!datasets.isEmpty()) {
             //this split is so that produced and reused datasets are not mixed in the table, to improve readability
             insertComposeTableDataAccess(xwpfTable, reusedDatasets);
             insertComposeTableDataAccess(xwpfTable, newDatasets);
@@ -940,7 +927,7 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
                 try {
                     newRow = insertNewTableRow(sourceTableRow, i + 2);
                 }
-                catch (Exception e) {
+                catch (Exception ignored) {
                 }
 
                 ArrayList<String> docVar = new ArrayList<String>();
@@ -981,29 +968,15 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
                     } else
                         docVar.add("");
                 }
-                //TODO datasets and hosts are now connected by Distribution objects
-                if (newDatasets.get(i).getDistributionList() != null){
-                    List<Distribution> distributions = newDatasets.get(i).getDistributionList();
-                    List<String> repositories = new ArrayList<>();
-                    if (!distributions.isEmpty()) {
-                        for (Distribution distribution: distributions) {
-                            if (Repository.class.isAssignableFrom(distribution.getHost().getClass()))
-                                repositories.add(distribution.getHost().getTitle());
-                        }
-                    }
-                    if (!repositories.isEmpty()) {
-                        docVar.add(String.join(", ", repositories));
-                    }
-                    else {
-                        docVar.add("");
-                    }
-                }
-                else {
-                    docVar.add("");
-                }
+                List<Repository> repositories = newDatasets.get(i).getRepositories();
+                List<String> repositoryTitles = repositories.stream().map(Repository::getTitle).toList();
+                docVar.add(joinWithComma(repositoryTitles));
 
-                //TODO: PID not yet defined
-                docVar.add("");
+                Set<EIdentifierType> pids = new HashSet<>();
+                for (Repository repository: repositories) {
+                    pids.addAll(repositoriesService.getPidSystems(repository.getRepositoryId()));
+                }
+                docVar.add(joinWithComma(pids.stream().map(EIdentifierType::getType).toList()));
 
                 //suppress license information for closed datasets
                 if (newDatasets.get(i).getLicense() != null
@@ -1035,8 +1008,8 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
     public void composeTableDatasetRepository(XWPFTable xwpfTable){
         log.debug("Export steps: Dataset Repository Table");
 
-        List<Dataset> newDatasets = getNewDatasets().stream().filter(dataset -> !dataset.getDelete()).collect(Collectors.toList());
-        if (newDatasets.size() > 0) {
+        List<Dataset> newDatasets = getNewDatasets().stream().filter(dataset -> !dataset.getDelete()).toList();
+        if (!newDatasets.isEmpty()) {
             for (int i = 0; i < newDatasets.size(); i++) {
 
                 XWPFTableRow sourceTableRow = xwpfTable.getRow(2);
@@ -1049,21 +1022,9 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
 
                 ArrayList<String> docVar = new ArrayList<>();
                 docVar.add(datasetTableIDs.get(newDatasets.get(i).id));
-                if (newDatasets.get(i).getDistributionList() != null) {
-                    List<Distribution> distributions = newDatasets.get(i).getDistributionList();
-                    List<String> repositories = new ArrayList<>();
-                    for (Distribution distribution : distributions) {
-                        if (Repository.class.isAssignableFrom(distribution.getHost().getClass()))
-                            repositories.add(distribution.getHost().getTitle());
-                    }
-                    if (repositories.size() > 0) {
-                        docVar.add(multipleVariable(repositories));
-                    } else {
-                        docVar.add("");
-                    }
-                } else {
-                    docVar.add("");
-                }
+                List<Repository> repositories = newDatasets.get(i).getRepositories();
+                List<String> repositoryTitles = repositories.stream().map(Repository::getTitle).toList();
+                docVar.add(joinWithComma(repositoryTitles));
 
                 if (newDatasets.get(i).getRetentionPeriod() != null)
                     docVar.add(newDatasets.get(i).getRetentionPeriod() + " years");
@@ -1097,7 +1058,7 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
     public void composeTableDatasetDeletion(XWPFDocument document, XWPFTable xwpfTable){
         log.debug("Export steps: Dataset Deletion Table");
 
-        if (deletedDatasets.size() > 0) {
+        if (!deletedDatasets.isEmpty()) {
 
             for (int i = 0; i < deletedDatasets.size(); i++) {
                 XWPFTableRow sourceTableRow = xwpfTable.getRow(2);
@@ -1146,7 +1107,7 @@ public abstract class AbstractTemplateExportScienceEuropeComponents extends Abst
         log.debug("Export steps: Cost Table");
 
         Float totalCost = 0f;
-        if (costList.size() > 0) {
+        if (!costList.isEmpty()) {
             for (int i = 0; i < costList.size(); i++) {
                 XWPFTableRow sourceTableRow = xwpfTable.getRow(2);
                 XWPFTableRow newRow = new XWPFTableRow(sourceTableRow.getCtRow(), xwpfTable);

--- a/src/main/java/at/ac/tuwien/damap/conversion/ExportHorizonEuropeTemplate.java
+++ b/src/main/java/at/ac/tuwien/damap/conversion/ExportHorizonEuropeTemplate.java
@@ -2,6 +2,7 @@ package at.ac.tuwien.damap.conversion;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
 import org.apache.poi.xwpf.usermodel.XWPFTable;
@@ -118,18 +119,10 @@ public class ExportHorizonEuropeTemplate extends AbstractTemplateExportScienceEu
 
                 ArrayList<String> docVar = new ArrayList<>();
                 docVar.add(datasetTableIDs.get(newDatasets.get(i).id));
-                if (newDatasets.get(i).getDistributionList() != null) {
-                    List<Distribution> distributions = newDatasets.get(i).getDistributionList();
-                    List<String> repositories = new ArrayList<>();
-                    for (Distribution distribution : distributions) {
-                        if (Repository.class.isAssignableFrom(distribution.getHost().getClass()))
-                            repositories.add(distribution.getHost().getTitle());
-                    }
-                    if (!repositories.isEmpty()) {
-                        docVar.add(multipleVariable(repositories));
-                    } else {
-                        docVar.add("");
-                    }
+                List<Repository> repositories = newDatasets.get(i).getRepositories();
+                if (!repositories.isEmpty()) {
+                    List<String> repositoryTitles = repositories.stream().map(Repository::getTitle).toList();
+                    docVar.add(joinWithComma(repositoryTitles));
                 } else {
                     docVar.add("");
                 }

--- a/src/main/java/at/ac/tuwien/damap/domain/Dataset.java
+++ b/src/main/java/at/ac/tuwien/damap/domain/Dataset.java
@@ -109,6 +109,15 @@ public class Dataset extends PanacheEntity {
     @Column(name = "dataset_source")
     private EDataSource source;
 
+    public List<Repository> getRepositories() {
+        List<Repository> repositories = new ArrayList<>();
+        for (Distribution distribution : this.getDistributionList()) {
+            if (Repository.class.isAssignableFrom(distribution.getHost().getClass()))
+                repositories.add((Repository) distribution.getHost());
+        }
+        return repositories;
+    }
+
     @EqualsAndHashCode.Include
     public Long getId() {
         return id;

--- a/src/main/java/at/ac/tuwien/damap/enums/EIdentifierType.java
+++ b/src/main/java/at/ac/tuwien/damap/enums/EIdentifierType.java
@@ -5,16 +5,19 @@ import java.util.List;
 
 public enum EIdentifierType {
 
-    ORCID("orcid"),
-    ISNI("isni"),
-    OPENID("openid"),
-    OTHER("other"),
-    HANDLE("handle"),
-    DOI("doi"),
-    ARK("ark"),
-    URL("url"),
-    FUNDREF("fundref"),
-    ROR("ror");
+    ORCID("ORCID"),
+    ISNI("ISNI"),
+    OPENID("OpenId"),
+    OTHER("Other"),
+    HANDLE("Handle"),
+    DOI("DOI"),
+    ARK("ARK"),
+    URL("URL"),
+    HDL("HDL"),
+    PURL("PURL"),
+    URN("URN"),
+    FUNDREF("FundRef"),
+    ROR("ROR");
 
     private final String type;
 
@@ -35,6 +38,9 @@ public enum EIdentifierType {
         datasetIdentifierType.add(EIdentifierType.ARK);
         datasetIdentifierType.add(EIdentifierType.URL);
         datasetIdentifierType.add(EIdentifierType.OTHER);
+        datasetIdentifierType.add(EIdentifierType.HDL);
+        datasetIdentifierType.add(EIdentifierType.PURL);
+        datasetIdentifierType.add(EIdentifierType.URN);
 
         funderIdentifierType.add(EIdentifierType.FUNDREF);
         funderIdentifierType.add(EIdentifierType.URL);
@@ -53,7 +59,11 @@ public enum EIdentifierType {
         this.type = type;
     }
 
-    public List<EIdentifierType> getPersonIdentifierTypeList() {
+    public String getType() {
+        return type;
+    }
+
+    public static List<EIdentifierType> getPersonIdentifierTypeList() {
         return personIdentifierType;
     }
 

--- a/src/main/java/at/ac/tuwien/damap/r3data/RepositoriesService.java
+++ b/src/main/java/at/ac/tuwien/damap/r3data/RepositoriesService.java
@@ -1,5 +1,6 @@
 package at.ac.tuwien.damap.r3data;
 
+import at.ac.tuwien.damap.enums.EIdentifierType;
 import at.ac.tuwien.damap.r3data.dto.RepositoryDetails;
 import at.ac.tuwien.damap.r3data.mapper.RepositoryMapper;
 import generated.Repository;
@@ -79,5 +80,9 @@ public class RepositoriesService {
 
     public String getRepositoryURL(String id) {
         return RepositoryMapper.mapToRepositoryDetails(getById(id), id).getRepositoryURL();
+    }
+
+    public List<EIdentifierType> getPidSystems(String id) {
+        return RepositoryMapper.mapToRepositoryDetails(getById(id), id).getPidSystems();
     }
 }

--- a/src/main/java/at/ac/tuwien/damap/r3data/dto/RepositoryDetails.java
+++ b/src/main/java/at/ac/tuwien/damap/r3data/dto/RepositoryDetails.java
@@ -1,5 +1,7 @@
 package at.ac.tuwien.damap.r3data.dto;
 
+import at.ac.tuwien.damap.domain.Identifier;
+import at.ac.tuwien.damap.enums.EIdentifierType;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 
@@ -18,5 +20,6 @@ public class RepositoryDetails {
     private Boolean versioning;
     private List<String> contentTypes;
     private List<String> metadataStandards;
+    private List<EIdentifierType> pidSystems;
 
 }

--- a/src/main/java/at/ac/tuwien/damap/r3data/mapper/RepositoryMapper.java
+++ b/src/main/java/at/ac/tuwien/damap/r3data/mapper/RepositoryMapper.java
@@ -1,12 +1,15 @@
 package at.ac.tuwien.damap.r3data.mapper;
 
+import at.ac.tuwien.damap.enums.EIdentifierType;
 import at.ac.tuwien.damap.r3data.dto.RepositoryDetails;
 import lombok.experimental.UtilityClass;
 import org.re3data.schema._2_2.Languages;
+import org.re3data.schema._2_2.PidSystems;
 import org.re3data.schema._2_2.Re3Data;
 import org.re3data.schema._2_2.Yesno;
 
 import java.util.ArrayList;
+import java.util.List;
 
 @UtilityClass
 public class RepositoryMapper {
@@ -49,6 +52,15 @@ public class RepositoryMapper {
             }
             repositoryDetails.setContentTypes(types);
         }
+
+        List<PidSystems> pidSystems = repo.getPidSystem();
+        List<EIdentifierType> pidIdentifiers = new ArrayList<>();
+        for (PidSystems pidSystem : pidSystems) {
+            if (!pidSystem.name().equals("NONE")) {
+                pidIdentifiers.add(EIdentifierType.valueOf(pidSystem.name()));
+            }
+        }
+        repositoryDetails.setPidSystems(pidIdentifiers);
 
         return repositoryDetails;
     }

--- a/src/main/resources/at/ac/tuwien/damap/db/changeLog-4.x/changeLog-4.0.0_2.yaml
+++ b/src/main/resources/at/ac/tuwien/damap/db/changeLog-4.x/changeLog-4.0.0_2.yaml
@@ -1,0 +1,23 @@
+databaseChangeLog:
+  - changeSet:
+      id: 11
+      author: Valentin Futterer
+      changes:
+        - insert:
+            tableName: e_identifier_type
+            columns:
+              - column:
+                  name: type
+                  value: 'HDL'
+        - insert:
+            tableName: e_identifier_type
+            columns:
+              - column:
+                  name: type
+                  value: 'PURL'
+        - insert:
+            tableName: e_identifier_type
+            columns:
+              - column:
+                  name: type
+                  value: 'URN'

--- a/src/main/resources/at/ac/tuwien/damap/db/changeLog-root.yaml
+++ b/src/main/resources/at/ac/tuwien/damap/db/changeLog-root.yaml
@@ -17,3 +17,5 @@ databaseChangeLog:
       file: at/ac/tuwien/damap/db/changeLog-3.x/changeLog-3.0.0_1.yaml
   - include:
       file: at/ac/tuwien/damap/db/changeLog-4.x/changeLog-4.0.0_1.yaml
+  - include:
+      file: at/ac/tuwien/damap/db/changeLog-4.x/changeLog-4.0.0_2.yaml

--- a/src/test/java/at/ac/tuwien/damap/conversion/AbstractTemplateExportFunctionsTest.java
+++ b/src/test/java/at/ac/tuwien/damap/conversion/AbstractTemplateExportFunctionsTest.java
@@ -25,10 +25,10 @@ class AbstractTemplateExportFunctionsTest {
             Assertions.assertNotNull(document);
 
             //testing multiple variable handling
-            String result1 = documentConversionService.multipleVariable(testTwoVariable());
-            String result2 = documentConversionService.multipleVariable(testThreeVariable());
-            String result3 = documentConversionService.multipleVariableAnd(testTwoVariable());
-            String result4 = documentConversionService.multipleVariableAnd(testThreeVariable());
+            String result1 = documentConversionService.joinWithComma(testTwoVariable());
+            String result2 = documentConversionService.joinWithComma(testThreeVariable());
+            String result3 = documentConversionService.joinWithCommaAnd(testTwoVariable());
+            String result4 = documentConversionService.joinWithCommaAnd(testThreeVariable());
             Assertions.assertEquals(twoVariables(), result1);
             Assertions.assertEquals(threeVariables(), result2);
             Assertions.assertEquals(twoVariablesAnd(), result3);
@@ -55,10 +55,10 @@ class AbstractTemplateExportFunctionsTest {
     }
 
     private String twoVariablesAnd() {
-        return "var1, and var2";
+        return "var1 and var2";
     }
 
     private String threeVariablesAnd() {
-        return "var1, var2, and var3";
+        return "var1, var2 and var3";
     }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
Feature

#### What does this PR do?
Takes the supported PID-System from the repository information available through R3Data and fills the info in the PID column in the templates. Since R3Data supported more identifiers than damap had as enums, a database change was necessary to update them. The enums are HDL, PURL and URN.

### Checks
<!-- Adjust list as necessary -->
<!-- In case of DB changes make sure that names do not exceed 30 chars and that audit tables have been created/updated and do not contain FKs on entities. -->
- [ ] Tested with Oracle/PostgreSQL
- [ ] Export updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-98, GH-115
