### PR TITLE
git: update git ignore commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -2,4 +2,4 @@
 18adc4c146b63082af770f9e78b8983e03df0b6c
 
 # Apply code formatter globally
-cdc04b0d5c08bc4e115e4bf00cce82d2bb1ed13e
+ed1e5ee3feb921c46cd86a8e517c105301076b56


### PR DESCRIPTION
Update the commit for applying the code formatter globally.

Commit can be found here: https://github.com/tuwien-csd/damap-backend/commit/ed1e5ee3feb921c46cd86a8e517c105301076b56