### PR TITLE
Extend DatasetSizeRange enum to match frontend FILE_SIZES

### DIFF
--- a/src/main/java/org/damap/base/conversion/AbstractTemplateExportScienceEuropeComponents.java
+++ b/src/main/java/org/damap/base/conversion/AbstractTemplateExportScienceEuropeComponents.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import lombok.extern.jbosslog.JBossLog;
 import org.apache.poi.xwpf.usermodel.*;
 import org.damap.base.domain.*;
+import org.damap.base.domain.DatasetSizeRange;
 import org.damap.base.enums.*;
 import org.damap.base.rest.dmp.domain.ProjectDO;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTVMerge;
@@ -858,7 +859,7 @@ public abstract class AbstractTemplateExportScienceEuropeComponents
         docVar.add("");
 
         if (newDatasets.get(i).getSize() != null) {
-          docVar.add(format(newDatasets.get(i).getSize()) + "B");
+          docVar.add(DatasetSizeRange.getLabelForSize(newDatasets.get(i).getSize()));
         } else {
           docVar.add("");
         }

--- a/src/main/java/org/damap/base/domain/DatasetSizeRange.java
+++ b/src/main/java/org/damap/base/domain/DatasetSizeRange.java
@@ -1,0 +1,56 @@
+package org.damap.base.domain;
+
+public enum DatasetSizeRange {
+  LESS_THAN_100MB(0, 99_999_999L, "< 100 MB"),
+  FROM_100MB_TO_1GB(100_000_000L, 999_999_999L, "100 - 1000 MB"),
+  FROM_1GB_TO_5GB(1_000_000_000L, 4_999_999_999L, "1 - 5 GB"),
+  FROM_5GB_TO_20GB(5_000_000_000L, 19_999_999_999L, "5 - 20 GB"),
+  FROM_20GB_TO_50GB(20_000_000_000L, 49_999_999_999L, "20 - 50 GB"),
+  FROM_50GB_TO_100GB(50_000_000_000L, 99_999_999_999L, "50 - 100 GB"),
+  FROM_100GB_TO_500GB(100_000_000_000L, 499_999_999_999L, "100 - 500 GB"),
+  FROM_500GB_TO_1TB(500_000_000_000L, 999_999_999_999L, "500 - 1000 GB"),
+  FROM_1TB_TO_5TB(1_000_000_000_000L, 4_999_999_999_999L, "1 - 5 TB"),
+  FROM_5TB_TO_10TB(5_000_000_000_000L, 9_999_999_999_999L, "5 - 10 TB"),
+  FROM_10TB_TO_100TB(10_000_000_000_000L, 99_999_999_999_999L, "10 - 100 TB"),
+  FROM_100TB_TO_500TB(100_000_000_000_000L, 499_999_999_999_999L, "100 - 500 TB"),
+  FROM_500TB_TO_1PB(500_000_000_000_000L, 999_999_999_999_999L, "500 - 1000 TB"),
+  MORE_THAN_1PB(1_000_000_000_000_000L, Long.MAX_VALUE, "> 1 PB"),
+  UNKNOWN(-1, -1, "I don't know yet");
+
+  private final long minSize;
+  private final long maxSize;
+  private final String label;
+
+  DatasetSizeRange(long minSize, long maxSize, String label) {
+    this.minSize = minSize;
+    this.maxSize = maxSize;
+    this.label = label;
+  }
+
+  public long getMinSize() {
+    return minSize;
+  }
+
+  public long getMaxSize() {
+    return maxSize;
+  }
+
+  public String getLabel() {
+    return label;
+  }
+
+  /**
+   * Retrieves the label for a given size.
+   *
+   * @param size the size to evaluate
+   * @return the corresponding label of the size range
+   */
+  public static String getLabelForSize(long size) {
+    for (DatasetSizeRange range : values()) {
+      if (size >= range.getMinSize() && size <= range.getMaxSize()) {
+        return range.getLabel();
+      }
+    }
+    return "Unknown size";
+  }
+}

--- a/src/test/java/org/damap/base/conversion/AbstractTemplateExportScienceEuropeComponentsTest.java
+++ b/src/test/java/org/damap/base/conversion/AbstractTemplateExportScienceEuropeComponentsTest.java
@@ -8,6 +8,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import lombok.extern.jbosslog.JBossLog;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.damap.base.domain.DatasetSizeRange;
 import org.damap.base.rest.dmp.domain.DmpDO;
 import org.damap.base.rest.dmp.domain.ProjectDO;
 import org.damap.base.rest.persons.orcid.ORCIDPersonServiceImpl;
@@ -46,6 +47,11 @@ class AbstractTemplateExportScienceEuropeComponentsTest
     DmpDO dmpDO = testDOFactory.getOrCreateTestDmpDO();
     exportSetup(dmpDO.getId());
     Assertions.assertEquals(datasetTableIDs.size(), datasets.size(), dmpDO.getDatasets().size());
+  }
+
+  @Test
+  void testAddLabelForDatasetSize() {
+    Assertions.assertEquals("500 - 1000 GB", DatasetSizeRange.getLabelForSize(500_000_000_000L));
   }
 
   @Test

--- a/src/test/java/org/damap/base/domain/DatasetSizeRangeTest.java
+++ b/src/test/java/org/damap/base/domain/DatasetSizeRangeTest.java
@@ -1,0 +1,50 @@
+package org.damap.base.domain;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class DatasetSizeRangeTest {
+
+  @Test
+  void testGetLabelForSize() {
+    Object[][] testCases = {
+      {0L, "< 100 MB"},
+      {99_999_999L, "< 100 MB"},
+      {100_000_000L, "100 - 1000 MB"},
+      {999_999_999L, "100 - 1000 MB"},
+      {1_000_000_000L, "1 - 5 GB"},
+      {4_999_999_999L, "1 - 5 GB"},
+      {5_000_000_000L, "5 - 20 GB"},
+      {19_999_999_999L, "5 - 20 GB"},
+      {20_000_000_000L, "20 - 50 GB"},
+      {49_999_999_999L, "20 - 50 GB"},
+      {50_000_000_000L, "50 - 100 GB"},
+      {99_999_999_999L, "50 - 100 GB"},
+      {100_000_000_000L, "100 - 500 GB"},
+      {499_999_999_999L, "100 - 500 GB"},
+      {500_000_000_000L, "500 - 1000 GB"},
+      {999_999_999_999L, "500 - 1000 GB"},
+      {1_000_000_000_000L, "1 - 5 TB"},
+      {4_999_999_999_999L, "1 - 5 TB"},
+      {5_000_000_000_000L, "5 - 10 TB"},
+      {9_999_999_999_999L, "5 - 10 TB"},
+      {10_000_000_000_000L, "10 - 100 TB"},
+      {99_999_999_999_999L, "10 - 100 TB"},
+      {100_000_000_000_000L, "100 - 500 TB"},
+      {499_999_999_999_999L, "100 - 500 TB"},
+      {500_000_000_000_000L, "500 - 1000 TB"},
+      {999_999_999_999_999L, "500 - 1000 TB"},
+      {1_000_000_000_000_000L, "> 1 PB"},
+      {Long.MAX_VALUE, "> 1 PB"},
+      {-1000L, "Unknown size"}
+    };
+
+    for (Object[] testCase : testCases) {
+      long size = (long) testCase[0];
+      String expectedLabel = (String) testCase[1];
+      Assertions.assertEquals(expectedLabel, DatasetSizeRange.getLabelForSize(size));
+    }
+  }
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->

#### What does this PR do?
- Added DatasetSizeRange to include all size categories matching the frontend FILE_SIZES.

#### Breaking changes
<!-- Whether this PR contains breaking changes and which -->

#### Code review focus
![grafik](https://github.com/tuwien-csd/damap-backend/assets/112856634/efe28737-cc61-4d19-86ec-bdbafe62d109)

#### Dependencies
<!-- If this PR depends on or requires other/additional (frontend) changes, please list them here -->

### Checks
<!-- Adjust list as necessary -->
<!-- In case of DB changes make sure that names do not exceed 30 chars and that audit tables have been created/updated and do not contain FKs on entities. -->
- [ ] Tested with Oracle/PostgreSQL
- [ ] Export updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-<!-- insert issue number -->
