### PR TITLE
nginx: add rules for openapi docs

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -20,5 +20,11 @@ http {
         location /api/ {
             proxy_pass http://damap-be:8080;
         }
+        location /q/swagger-ui {
+            proxy_pass http://damap-be:8080;
+        }
+        location /q/openapi {
+            proxy_pass http://damap-be:8080;
+        }
     }
 }


### PR DESCRIPTION
Makes swagger UI and OpenAPI accessible in a dockerized setup.