### PR TITLE
Global: Remove duplicate dataset based on DOI

### DIFF
--- a/src/main/java/org/damap/base/rest/dmp/service/DmpConsistencyUtility.java
+++ b/src/main/java/org/damap/base/rest/dmp/service/DmpConsistencyUtility.java
@@ -1,6 +1,7 @@
 package org.damap.base.rest.dmp.service;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -147,6 +148,32 @@ public class DmpConsistencyUtility {
         datasetDO.setDateOfDeletion(null);
       }
     }
+
+    HashSet<String> seenDatasetDOI = new HashSet<>();
+    List<DatasetDO> uniqueDatasets = new ArrayList<>();
+
+    for (DatasetDO datasetDO : dmpDO.getDatasets()) {
+      if (datasetDO.getSource() == EDataSource.REUSED) {
+        // We have a reused dataset
+        if (datasetDO.getDatasetId() != null
+            && datasetDO.getDatasetId().getType() == EIdentifierType.DOI) {
+          // No duplicate DOIs - only add if not seen before
+          String datasetDOI = datasetDO.getDatasetId().getIdentifier();
+          if (!seenDatasetDOI.contains(datasetDOI)) {
+            uniqueDatasets.add(datasetDO);
+            seenDatasetDOI.add(datasetDOI);
+          }
+        } else {
+          // Manual entry - always add
+          uniqueDatasets.add(datasetDO);
+        }
+      } else {
+        // New dataset - always add
+        uniqueDatasets.add(datasetDO);
+      }
+    }
+
+    dmpDO.setDatasets(uniqueDatasets);
   }
 
   /**


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
Feature

#### What does this PR do?
Added backend validation for datasets to remove duplicate (used) datasets based on their DOI

#### Dependencies
Related frontend issue:
https://github.com/tuwien-csd/damap-frontend/pull/290

### Checks
<!-- Adjust list as necessary -->
<!-- In case of DB changes make sure that names do not exceed 30 chars and that audit tables have been created/updated and do not contain FKs on entities. -->
- [ ] Tested with Oracle/PostgreSQL
- [ ] Export updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-239
