### PR TITLE
docker: move extra services to own file

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -18,7 +18,16 @@ To start up the cluster of components just issue the following command:
 
 ```shell
 cd docker
-docker-compose up -d
+docker compose up -d
+```
+
+For local development, it is often enough to only run the additional services,
+as the local development instances for backend and frontend are used.
+
+To only start the additional services, the following command can be issued:
+```shell
+cd docker
+docker compose -f docker-compose-services.yaml up -d
 ```
 
 See the documented sections in the [docker/docker-compose.yaml]() to make further

--- a/docker/docker-compose-services.yaml
+++ b/docker/docker-compose-services.yaml
@@ -1,0 +1,71 @@
+version: '3.3'
+
+services:
+  damap-db:
+    image: postgres:16
+    pull_policy: always
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: damap
+      POSTGRES_PASSWORD: pw4damap
+      POSTGRES_DB: damap
+    ports:
+      - "8088:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "sh -c 'pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}'"]
+      interval: 30s
+      timeout: 15s
+      retries: 5
+
+  keycloak:
+    image: bitnami/keycloak:23
+    pull_policy: always
+    restart: unless-stopped
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+
+      KEYCLOAK_DATABASE_HOST: keycloak-db
+      KEYCLOAK_DATABASE_NAME: keycloak
+      KEYCLOAK_DATABASE_USER: keycloak
+      KEYCLOAK_DATABASE_PORT: 5432
+      KEYCLOAK_DATABASE_PASSWORD: keycloak
+
+      # Import realms found in /opt/bitnami/keycloak/data/import
+      KEYCLOAK_EXTRA_ARGS: "--import-realm"
+    ports:
+      - "8087:8080"
+    volumes:
+      - ./sample-damap-realm-export.json:/opt/bitnami/keycloak/data/import/sample-damap-realm-export.json
+
+  keycloak-db:
+   image: postgres:16
+   environment:
+     POSTGRES_USER: keycloak
+     POSTGRES_PASSWORD: keycloak
+     POSTGRES_DB: keycloak
+     DB_VENDOR: postgres
+
+  api-mock:
+    image: clue/json-server
+    pull_policy: always
+    restart: unless-stopped
+    command: db.json --routes routes.json
+    volumes:
+      - ./api-mock/data/db.json:/data/db.json
+      - ./api-mock/data/routes.json:/data/routes.json
+    ports:
+      - "8091:80"
+
+  fits-service:
+    image: islandora/fits:main
+    pull_policy: always
+    restart: unless-stopped
+    ports:
+      - "8089:8080"
+
+# Uncomment the following block to persist postgres data.
+#    volumes:
+#      - damap-db-data:/var/lib/postgresql/data
+#volumes:
+#  damap-db-data:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,6 +1,10 @@
 version: '3.3'
 
+include:
+  - docker-compose-services.yaml
+
 services:
+
   damap-be:
     # Since DAMAP containers are publicly available on Github packages one can
     # just pull the latest container image.
@@ -23,51 +27,6 @@ services:
       timeout: 15s
       retries: 5
 
-  damap-db:
-    image: postgres:16
-    pull_policy: always
-    restart: unless-stopped
-    environment:
-      POSTGRES_USER: damap
-      POSTGRES_PASSWORD: pw4damap
-      POSTGRES_DB: damap
-    ports:
-      - "8088:5432"
-    healthcheck:
-      test: ["CMD-SHELL", "sh -c 'pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}'"]
-      interval: 30s
-      timeout: 15s
-      retries: 5
-
-  keycloak:
-    image: bitnami/keycloak:23
-    pull_policy: always
-    restart: unless-stopped
-    environment:
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
-
-      KEYCLOAK_DATABASE_HOST: keycloak-db
-      KEYCLOAK_DATABASE_NAME: keycloak
-      KEYCLOAK_DATABASE_USER: keycloak
-      KEYCLOAK_DATABASE_PORT: 5432
-      KEYCLOAK_DATABASE_PASSWORD: keycloak
-
-      # Import realms found in /opt/bitnami/keycloak/data/import
-      KEYCLOAK_EXTRA_ARGS: "--import-realm"
-    ports:
-      - "8087:8080"
-    volumes:
-      - ./sample-damap-realm-export.json:/opt/bitnami/keycloak/data/import/sample-damap-realm-export.json
-
-  keycloak-db:
-   image: postgres:16
-   environment:
-     POSTGRES_USER: keycloak
-     POSTGRES_PASSWORD: keycloak
-     POSTGRES_DB: keycloak
-     DB_VENDOR: postgres
-
   damap-fe:
     # Since DAMAP containers are publicly available on Github packages one can
     # just pull the latest container image.
@@ -82,17 +41,6 @@ services:
       # context: ../../damap-frontend
     depends_on:
       - damap-be
-
-  api-mock:
-    image: clue/json-server
-    pull_policy: always
-    restart: unless-stopped
-    command: db.json --routes routes.json
-    volumes:
-      - ./api-mock/data/db.json:/data/db.json
-      - ./api-mock/data/routes.json:/data/routes.json
-    ports:
-      - "8091:80"
 
   proxy:
     # Since several components share the same ports and address, this docker


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->


#### What does this PR do?
<!-- Changes introduced by this PR - what happened before, what happens now -->
Split `docker-compose.yaml` file. One compose file only includes the services. For development, it is usually not relevant to have an extra backend and frontend running, since the local development instances for backend and frontend are used.

To run only the extra services, the following command can be executed:
`docker-compose -f docker-compose-services.yaml up`

#### Breaking changes
<!-- Whether this PR contains breaking changes and which -->
None

#### Code review focus
<!-- What you want the reviewer to focus on -->

#### Dependencies
<!-- If this PR depends on or requires other/additional (frontend) changes, please list them here -->

### Checks
<!-- Adjust list as necessary -->
<!-- In case of DB changes make sure that names do not exceed 30 chars and that audit tables have been created/updated and do not contain FKs on entities. -->
- [ ] Tested with Oracle/PostgreSQL
- [ ] Export updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge


