### PR TITLE
Export: Add missing null checks to cost export

### DIFF
--- a/src/main/java/org/damap/base/conversion/AbstractTemplateExportScienceEuropeComponents.java
+++ b/src/main/java/org/damap/base/conversion/AbstractTemplateExportScienceEuropeComponents.java
@@ -1317,11 +1317,10 @@ public abstract class AbstractTemplateExportScienceEuropeComponents
         }
 
         ArrayList<String> docVar = new ArrayList<>();
-        docVar.add(costList.get(i).getTitle());
-        if (costList.get(i).getType() != null) docVar.add(costList.get(i).getType().toString());
-        else docVar.add("");
-        docVar.add(costList.get(i).getDescription());
-        docVar.add(costList.get(i).getCurrencyCode());
+        docVar.add(Optional.ofNullable(costList.get(i).getTitle()).orElse(""));
+        docVar.add((costList.get(i).getType() != null) ? costList.get(i).getType().toString() : "");
+        docVar.add(Optional.ofNullable(costList.get(i).getDescription()).orElse(""));
+        docVar.add(Optional.ofNullable(costList.get(i).getCurrencyCode()).orElse("€"));
         if (costList.get(i).getValue() != null) {
           docVar.add(
               NumberFormat.getNumberInstance(Locale.GERMAN).format(costList.get(i).getValue()));


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
Bugfix

#### What does this PR do?
Add nullchecks before exporting costs to prevent NullPointerExceptions.

### Checks
<!-- Adjust list as necessary -->
<!-- In case of DB changes make sure that names do not exceed 30 chars and that audit tables have been created/updated and do not contain FKs on entities. -->
- [ ] Tested with Oracle/PostgreSQL
- [ ] Export updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-251
