### PR TITLE
Version: Update DmpListItemDO and add versionCount and latestVersionName for any given DMP

### DIFF
--- a/src/main/java/org/damap/base/rest/dmp/domain/DmpListItemDO.java
+++ b/src/main/java/org/damap/base/rest/dmp/domain/DmpListItemDO.java
@@ -24,4 +24,8 @@ public class DmpListItemDO {
   private String description;
   private ProjectDO project;
   private EFunctionRole accessType;
+
+  private Long versionCount;
+
+  private String latestVersionName;
 }

--- a/src/main/java/org/damap/base/rest/dmp/mapper/DmpListItemDOMapper.java
+++ b/src/main/java/org/damap/base/rest/dmp/mapper/DmpListItemDOMapper.java
@@ -1,11 +1,13 @@
 package org.damap.base.rest.dmp.mapper;
 
+import java.util.List;
 import lombok.experimental.UtilityClass;
 import org.damap.base.domain.Access;
 import org.damap.base.domain.Dmp;
 import org.damap.base.rest.dmp.domain.ContributorDO;
 import org.damap.base.rest.dmp.domain.DmpListItemDO;
 import org.damap.base.rest.dmp.domain.ProjectDO;
+import org.damap.base.rest.version.VersionDO;
 
 /** DmpListItemDOMapper class. */
 @UtilityClass
@@ -19,7 +21,8 @@ public class DmpListItemDOMapper {
    * @param dmpListItemDO a {@link org.damap.base.rest.dmp.domain.DmpListItemDO} object
    * @return a {@link org.damap.base.rest.dmp.domain.DmpListItemDO} object
    */
-  public DmpListItemDO mapEntityToDO(Access access, Dmp dmp, DmpListItemDO dmpListItemDO) {
+  public DmpListItemDO mapEntityToDO(
+      Access access, Dmp dmp, DmpListItemDO dmpListItemDO, List<VersionDO> versionDOList) {
     dmpListItemDO.setId(dmp.id);
     dmpListItemDO.setTitle(dmp.getTitle());
     dmpListItemDO.setCreated(dmp.getCreated());
@@ -39,6 +42,13 @@ public class DmpListItemDOMapper {
       ProjectDO projectDO = new ProjectDO();
       ProjectDOMapper.mapEntityToDO(dmp.getProject(), projectDO);
       dmpListItemDO.setProject(projectDO);
+    }
+
+    // Get the latest version from the versionDOList with the highest revision number
+    if (versionDOList != null && !versionDOList.isEmpty()) {
+      dmpListItemDO.setVersionCount((long) versionDOList.size());
+      dmpListItemDO.setLatestVersionName(
+          versionDOList.get(versionDOList.size() - 1).getVersionName());
     }
 
     return dmpListItemDO;

--- a/src/main/java/org/damap/base/rest/dmp/service/DmpService.java
+++ b/src/main/java/org/damap/base/rest/dmp/service/DmpService.java
@@ -65,7 +65,8 @@ public class DmpService {
     dmpList.forEach(
         dmp ->
             dmpListItemDOList.add(
-                DmpListItemDOMapper.mapEntityToDO(null, dmp, new DmpListItemDO())));
+                DmpListItemDOMapper.mapEntityToDO(
+                    null, dmp, new DmpListItemDO(), versionService.getDmpVersions(dmp.id))));
     return dmpListItemDOList;
   }
 
@@ -84,7 +85,11 @@ public class DmpService {
     accessList.forEach(
         access ->
             dmpListItemDOS.add(
-                DmpListItemDOMapper.mapEntityToDO(access, access.getDmp(), new DmpListItemDO())));
+                DmpListItemDOMapper.mapEntityToDO(
+                    access,
+                    access.getDmp(),
+                    new DmpListItemDO(),
+                    versionService.getDmpVersions(access.getDmp().id))));
     return dmpListItemDOS;
   }
 

--- a/src/main/java/org/damap/base/rest/version/VersionService.java
+++ b/src/main/java/org/damap/base/rest/version/VersionService.java
@@ -45,6 +45,12 @@ public class VersionService {
    */
   @Transactional
   public VersionDO createOrUpdate(VersionDO versionDO) {
+
+    if (versionDO.getVersionName().length() > 255) {
+      throw new IllegalArgumentException(
+          "Version name must be less than or equal to 255 characters");
+    }
+
     if (versionDO.getId() != null) return update(versionDO);
     else return create(versionDO);
   }


### PR DESCRIPTION
## Description
Feature / Bugfix

#### What does this PR do?
Added two fields to the DMPListItemDO (for the information to be displayed in the Frontend DMP Table).

#### Breaking changes
Fixed major bug, disabling the versioning feature in the DB by checking for a max length for the name of a new versioning of a DMP.

#### Dependencies
Frontend PR:
https://github.com/tuwien-csd/damap-frontend/pull/354


Issue:
https://github.com/tuwien-csd/damap-frontend/issues/346
