### PR TITLE
Export: Remove storage description from export if it null in the translation

### DIFF
--- a/src/main/java/org/damap/base/conversion/AbstractTemplateExportScienceEuropeComponents.java
+++ b/src/main/java/org/damap/base/conversion/AbstractTemplateExportScienceEuropeComponents.java
@@ -424,9 +424,10 @@ public abstract class AbstractTemplateExportScienceEuropeComponents
                       + " "
                       + loadResourceService.loadVariableFromResource(prop, "distributionStorage")
                       + " "
-                      + hostVar
-                      + ": "
-                      + storageDescription);
+                      + hostVar);
+          if (storageDescription != null && !storageDescription.isEmpty()) {
+            storageVar = storageVar.concat(": " + storageDescription);
+          }
         }
       } else if (ExternalStorage.class.isAssignableFrom(
           host.getClass())) { // case for external storage, will have null host Id


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
Remove storage description from export if it is null (to avoid ": null" in exported Word document)

#### What does this PR do?
Remove storage description from export if it is null (to avoid ": null" in exported Word document)

closes GH-273
