### PR TITLE
Global: Add sorting to DMPs, Storage, Datasets and other entities by ID to preserve order

### DIFF
--- a/src/main/java/org/damap/base/domain/Dmp.java
+++ b/src/main/java/org/damap/base/domain/Dmp.java
@@ -153,6 +153,7 @@ public class Dmp extends PanacheEntity {
       cascade = {CascadeType.ALL},
       orphanRemoval = true,
       fetch = FetchType.EAGER)
+  @OrderBy("id")
   private List<Contributor> contributorList = new ArrayList<>();
 
   @OneToMany(
@@ -160,6 +161,7 @@ public class Dmp extends PanacheEntity {
       cascade = {CascadeType.ALL},
       orphanRemoval = true,
       fetch = FetchType.EAGER)
+  @OrderBy("id")
   private List<Dataset> datasetList = new ArrayList<>();
 
   @OneToMany(
@@ -189,6 +191,7 @@ public class Dmp extends PanacheEntity {
       cascade = {CascadeType.ALL},
       orphanRemoval = true,
       fetch = FetchType.EAGER)
+  @OrderBy("id")
   private List<Cost> costs = new ArrayList<>();
 
   private String documentation;

--- a/src/main/java/org/damap/base/repo/DmpRepo.java
+++ b/src/main/java/org/damap/base/repo/DmpRepo.java
@@ -1,6 +1,7 @@
 package org.damap.base.repo;
 
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import io.quarkus.panache.common.Sort;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.List;
 import org.damap.base.domain.Dmp;
@@ -15,6 +16,6 @@ public class DmpRepo implements PanacheRepository<Dmp> {
    * @return a {@link java.util.List} object
    */
   public List<Dmp> getAll() {
-    return listAll();
+    return listAll(Sort.by("id"));
   }
 }

--- a/src/main/java/org/damap/base/repo/base/RepoSearch.java
+++ b/src/main/java/org/damap/base/repo/base/RepoSearch.java
@@ -1,6 +1,7 @@
 package org.damap.base.repo.base;
 
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import io.quarkus.panache.common.Sort;
 import jakarta.ws.rs.core.MultivaluedMap;
 import java.util.HashMap;
 import java.util.List;
@@ -50,6 +51,6 @@ public interface RepoSearch<T> extends PanacheRepository<T> {
       counter++;
     }
 
-    return list(query.toString(), params);
+    return find(query.toString(), Sort.by("id"), params).list();
   }
 }

--- a/src/main/java/org/damap/base/rest/dmp/mapper/DmpDOMapper.java
+++ b/src/main/java/org/damap/base/rest/dmp/mapper/DmpDOMapper.java
@@ -1,9 +1,6 @@
 package org.damap.base.rest.dmp.mapper;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import lombok.experimental.UtilityClass;
 import lombok.extern.jbosslog.JBossLog;
 import org.damap.base.domain.*;

--- a/src/main/java/org/damap/base/rest/dmp/service/DmpService.java
+++ b/src/main/java/org/damap/base/rest/dmp/service/DmpService.java
@@ -5,11 +5,7 @@ import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import lombok.extern.jbosslog.JBossLog;
 import org.damap.base.domain.Access;
 import org.damap.base.domain.Contributor;
@@ -67,6 +63,7 @@ public class DmpService {
             dmpListItemDOList.add(
                 DmpListItemDOMapper.mapEntityToDO(
                     null, dmp, new DmpListItemDO(), versionService.getDmpVersions(dmp.id))));
+
     return dmpListItemDOList;
   }
 
@@ -90,6 +87,9 @@ public class DmpService {
                     access.getDmp(),
                     new DmpListItemDO(),
                     versionService.getDmpVersions(access.getDmp().id))));
+
+    dmpListItemDOS.sort(Comparator.comparing(DmpListItemDO::getId));
+
     return dmpListItemDOS;
   }
 


### PR DESCRIPTION
## Description
<!-- Please select a type that best describes your PR -->
<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->
Feature / Functionality

#### What does this PR do?
Add sorting by ID for DMPs (getAll and get for logged in user), Storages, Datasets, Contributors and Costs within a DMP.

closes GH-293
