### PR TITLE
Ethical: Add ethical report URI to datamodel and DO, that can be disabled throught the config file

### DIFF
--- a/src/main/java/org/damap/base/conversion/AbstractTemplateExportScienceEuropeComponents.java
+++ b/src/main/java/org/damap/base/conversion/AbstractTemplateExportScienceEuropeComponents.java
@@ -969,6 +969,14 @@ public abstract class AbstractTemplateExportScienceEuropeComponents
     if (Boolean.TRUE.equals(dmp.getCommitteeReviewed())) {
       ethicalStatement +=
           loadResourceService.loadVariableFromResource(prop, "ethicalReviewed.avail");
+
+      if (dmp.getEthicalIssuesReport() != null && !dmp.getEthicalIssuesReport().isEmpty()) {
+        ethicalStatement +=
+            " "
+                + loadResourceService.loadVariableFromResource(prop, "ethicalReportIntro")
+                + " "
+                + dmp.getEthicalIssuesReport();
+      }
     }
 
     addReplacement(replacements, "[ethicalissues]", ethicalStatement);

--- a/src/main/java/org/damap/base/domain/Dmp.java
+++ b/src/main/java/org/damap/base/domain/Dmp.java
@@ -148,6 +148,9 @@ public class Dmp extends PanacheEntity {
   @Column(name = "committee_reviewed_cris")
   private Boolean committeeReviewedCris;
 
+  @Column(name = "ethical_issues_report")
+  private String ethicalIssuesReport;
+
   @OneToMany(
       mappedBy = "dmp",
       cascade = {CascadeType.ALL},

--- a/src/main/java/org/damap/base/rest/ConfigResource.java
+++ b/src/main/java/org/damap/base/rest/ConfigResource.java
@@ -42,6 +42,9 @@ public class ConfigResource {
   @ConfigProperty(name = "damap.gotenberg-url")
   Optional<URL> gotenbergUrl;
 
+  @ConfigProperty(name = "damap.fields.ethical-report-enabled")
+  boolean ethicalReportEnabled;
+
   @ConfigProperty(name = "damap.title", defaultValue = "DAMAP Tool")
   String appTitle;
 
@@ -62,6 +65,7 @@ public class ConfigResource {
     configDO.setPersonSearchServiceConfigs(personServiceConfigurations.getConfigs());
     configDO.setFitsServiceAvailable(getFitsServiceAvailability());
     configDO.setLivePreviewAvailable(getGotenbergServiceAvailability());
+    configDO.setEthicalReportEnabled(ethicalReportEnabled);
 
     return configDO;
   }

--- a/src/main/java/org/damap/base/rest/config/domain/ConfigDO.java
+++ b/src/main/java/org/damap/base/rest/config/domain/ConfigDO.java
@@ -17,6 +17,7 @@ public class ConfigDO {
   private List<ServiceConfig> personSearchServiceConfigs;
   private boolean fitsServiceAvailable;
   private boolean livePreviewAvailable;
+  private boolean ethicalReportEnabled;
   private String appTitle;
 
   public void setAppTitle(String appTitle) {

--- a/src/main/java/org/damap/base/rest/dmp/domain/DmpDO.java
+++ b/src/main/java/org/damap/base/rest/dmp/domain/DmpDO.java
@@ -96,6 +96,10 @@ public class DmpDO {
   private Boolean ethicalIssuesExistCris;
   private Boolean committeeReviewed;
   private Boolean committeeReviewedCris;
+
+  @Size(max = 255)
+  private String ethicalIssuesReport;
+
   private List<DatasetDO> datasets = new ArrayList<>();
   private List<RepositoryDO> repositories = new ArrayList<>();
   private List<StorageDO> storage = new ArrayList<>();

--- a/src/main/java/org/damap/base/rest/dmp/mapper/DmpDOMapper.java
+++ b/src/main/java/org/damap/base/rest/dmp/mapper/DmpDOMapper.java
@@ -69,6 +69,7 @@ public class DmpDOMapper {
     dmpDO.setCostsExist(dmp.getCostsExist());
     dmpDO.setCostsExistCris(dmp.getCostsExistCris());
     dmpDO.setDocumentation(dmp.getDocumentation());
+    dmpDO.setEthicalIssuesReport(dmp.getEthicalIssuesReport());
 
     List<ContributorDO> contributorDOList = new ArrayList<>();
     dmp.getContributorList()
@@ -218,6 +219,7 @@ public class DmpDOMapper {
     dmp.setCostsExist(dmpDO.getCostsExist());
     dmp.setCostsExistCris(dmpDO.getCostsExistCris());
     dmp.setDocumentation(dmpDO.getDocumentation());
+    dmp.setEthicalIssuesReport(dmpDO.getEthicalIssuesReport());
 
     // TODO also check for existing contributors based on Identifier, not just
     // universityId

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -33,6 +33,8 @@ damap:
     - display-text: 'ORCID'
       query-value: 'ORCID'
       class-name: 'org.damap.base.rest.persons.orcid.ORCIDPersonServiceImpl'
+  fields:
+    ethical-report-enabled: true
 
 invenio:
   disabled: true

--- a/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.3.1_2.yaml
+++ b/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.3.1_2.yaml
@@ -1,0 +1,24 @@
+databaseChangeLog:
+  - changeSet:
+      id: 19
+      author: Geoffrey Karnbach
+      changes:
+          - addColumn:
+                tableName: dmp
+                columns:
+                    - column:
+                          name: ethical_issues_report
+                          type: VARCHAR(255)
+          - addColumn:
+              tableName: dmp_aud
+              columns:
+                - column:
+                    name: ethical_issues_report
+                    type: VARCHAR(255)
+      rollback:
+          - dropColumn:
+                tableName: dmp
+                columnName: ethical_issues_report
+          - dropColumn:
+                tableName: dmp_aud
+                columnName: ethical_issues_report

--- a/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.x.yaml
+++ b/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.x.yaml
@@ -17,3 +17,5 @@ databaseChangeLog:
       file: org/damap/base/db/changeLog-4.x/changeLog-4.3.0_3.yaml
   - include:
       file: org/damap/base/db/changeLog-4.x/changeLog-4.3.1_1.yaml
+  - include:
+      file: org/damap/base/db/changeLog-4.x/changeLog-4.3.1_2.yaml

--- a/src/main/resources/org/damap/base/template/horizonEuropeTemplate.resource
+++ b/src/main/resources/org/damap/base/template/horizonEuropeTemplate.resource
@@ -55,6 +55,7 @@ legalRights.contact.default=Our institution has rights to the produced data and 
 
 ethical.no=No particular ethical issue is foreseen with the data to be used or produced by the project. This section will be updated if issues arise.
 ethicalReviewed.avail=The research plan of the project was reviewed by an ethics committee / a similar body.
+ethicalReportIntro=Ethical issue report number:
 ethicalStatement=Ethical issues in the project have been identified and discussed with the Ethics Coordinator. They are described in detail in separate documents.
 
 closeddatasetreasons.intro=Closed Dataset Reasons:

--- a/src/main/resources/org/damap/base/template/scienceEuropeTemplate.resource
+++ b/src/main/resources/org/damap/base/template/scienceEuropeTemplate.resource
@@ -49,6 +49,7 @@ legalRights.contact.default=Our institution has rights to the produced data and 
 
 ethical.no=No particular ethical issue is foreseen with the data to be used or produced by the project. This section will be updated if issues arise.
 ethicalReviewed.avail=The research plan of the project was reviewed by an ethics committee / a similar body.
+ethicalReportIntro=Ethical issue report number:
 ethicalStatement=Ethical issues in the project have been identified and discussed with the Ethics Coordinator. They are described in detail in separate documents.
 
 closeddatasetreasons.intro=Closed Dataset Reasons:


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
Feature

#### What does this PR do?
Add new Ethical Report URI field in the DB, DO. Possibility to disable it using the application.yaml file using the ConfigDO sent to the frontend.

#### Dependencies
[Related Fronted PR](https://github.com/tuwien-csd/damap-frontend/pull/397)

closes GH-292
