### PR TITLE
Mock Service: Add empty check before accessing first element of a response list

### DIFF
--- a/src/main/java/org/damap/base/rest/persons/MockUniversityPersonServiceImpl.java
+++ b/src/main/java/org/damap/base/rest/persons/MockUniversityPersonServiceImpl.java
@@ -3,6 +3,7 @@ package org.damap.base.rest.persons;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.MultivaluedMap;
+import java.util.List;
 import org.damap.base.rest.base.ResultList;
 import org.damap.base.rest.base.Search;
 import org.damap.base.rest.dmp.domain.ContributorDO;
@@ -21,7 +22,11 @@ public class MockUniversityPersonServiceImpl implements PersonService {
   /** {@inheritDoc} */
   @Override
   public ContributorDO read(String id, MultivaluedMap<String, String> queryParams) {
-    return mockPersonRestService.getContributorDetails(id).get(0);
+    List<ContributorDO> response = mockPersonRestService.getContributorDetails(id);
+    if (response.isEmpty()) {
+      return null;
+    }
+    return response.get(0);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/org/damap/base/rest/projects/MockProjectServiceImpl.java
+++ b/src/main/java/org/damap/base/rest/projects/MockProjectServiceImpl.java
@@ -45,7 +45,11 @@ public class MockProjectServiceImpl implements ProjectService {
   /** {@inheritDoc} */
   @Override
   public ContributorDO getProjectLeader(String projectId) {
-    return mockPersonRestService.getContributorSearchResult().get(0);
+    List<ContributorDO> response = mockPersonRestService.getContributorSearchResult();
+    if (response.isEmpty()) {
+      return null;
+    }
+    return response.get(0);
   }
 
   /** {@inheritDoc} */
@@ -60,7 +64,11 @@ public class MockProjectServiceImpl implements ProjectService {
   /** {@inheritDoc} */
   @Override
   public ProjectDO read(String id, MultivaluedMap<String, String> queryParams) {
-    return mockProjectRestService.getProjectDetails(id).get(0);
+    List<ProjectDO> response = mockProjectRestService.getProjectDetails(id);
+    if (response.isEmpty()) {
+      return null;
+    }
+    return response.get(0);
   }
 
   /** {@inheritDoc} */


### PR DESCRIPTION
## Description
Bugfix

#### What does this PR do?
Ensure that get is not used on an empty list with a hardcoded access index of 0.

closes GH-304
