### PR TITLE
Global: make project title configurable via environment variable

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -26,6 +26,8 @@ services:
       interval: 30s
       timeout: 15s
       retries: 5
+    environment:
+      DAMAP_TITLE: "DAMAP Tool"
 
   damap-fe:
     # Since DAMAP containers are publicly available on Github packages one can

--- a/src/main/java/org/damap/base/rest/ConfigResource.java
+++ b/src/main/java/org/damap/base/rest/ConfigResource.java
@@ -42,6 +42,9 @@ public class ConfigResource {
   @ConfigProperty(name = "damap.gotenberg-url")
   Optional<URL> gotenbergUrl;
 
+  @ConfigProperty(name = "damap.title", defaultValue = "DAMAP Tool")
+  String appTitle;
+
   /**
    * config.
    *
@@ -55,6 +58,7 @@ public class ConfigResource {
     configDO.setAuthScope(authScope);
     configDO.setAuthUser(authUser);
     configDO.setEnv(env);
+    configDO.setAppTitle(appTitle);
     configDO.setPersonSearchServiceConfigs(personServiceConfigurations.getConfigs());
     configDO.setFitsServiceAvailable(getFitsServiceAvailability());
     configDO.setLivePreviewAvailable(getGotenbergServiceAvailability());

--- a/src/main/java/org/damap/base/rest/config/domain/ConfigDO.java
+++ b/src/main/java/org/damap/base/rest/config/domain/ConfigDO.java
@@ -17,4 +17,13 @@ public class ConfigDO {
   private List<ServiceConfig> personSearchServiceConfigs;
   private boolean fitsServiceAvailable;
   private boolean livePreviewAvailable;
+  private String appTitle;
+
+  public void setAppTitle(String appTitle) {
+    this.appTitle = appTitle;
+  }
+
+  public String getAppTitle() {
+    return appTitle;
+  }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,7 @@
 # custom config settings
 # replace these in the config of your custom project or by overriding these variables
 damap:
+  title: ${DAMAP_TITLE:DAMAP Tool}
   env: DEV # override in your custom project with PROD for production deployment
   origins: http://localhost:8085 # https://your.frontend.com,https://*.yourdomain.com
   auth:
@@ -99,6 +100,7 @@ rest:
 
 "%dev":
   damap:
+    title: "DAMAP (Development)"
     origins: http://localhost:4200
     auth:
       backend:
@@ -128,6 +130,7 @@ rest:
 
 "%test":
   damap:
+    title: "DAMAP (Testing)"
     repositories:
       recommendation: ['r3d100010468'] # Re3Data id(s)
   quarkus:


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

#### What does this PR do?
This PR adds support for dynamic project title configuration via an environment variable (DAMAP_TITLE). Previously, the project title was hardcoded. With this change, the title can now be set dynamically using the environment variable.

#### Breaking changes
This PR does not introduce breaking changes. If DAMAP_TITLE is not provided, the application will default to “DAMAP Tool.”

#### Code review focus
Ensure the environment variable is correctly injected into the application configuration.
Confirm the dynamic title is exposed via the /api/config endpoint.
Verify the backward compatibility when DAMAP_TITLE is not defined.

#### Steps
_Backend Logic Update:_

- 	Updated the application.yaml file to allow reading the DAMAP_TITLE environment variable.
- 	Added a default value (DAMAP Tool) to ensure backward compatibility.
- 	Injected the environment variable into the ConfigResource class.
- 	Passed the dynamic title to the ConfigDO object.

_API Update:_
	Extended the /api/config endpoint to include the appTitle field, reflecting the dynamic value of DAMAP_TITLE.
Testing and Verification:

- Tested DAMAP_TITLE
- Confirmed the dynamic title is displayed in the API response:

![Screenshot 2025-01-15 at 09 49 20](https://github.com/user-attachments/assets/240fd34b-8878-4958-b85e-78528f16bb89)

_Docker Configuration:_

- Set DAMAP_TITLE in the Docker Compose environment

### Checks
<!-- Adjust list as necessary -->
<!-- In case of DB changes make sure that names do not exceed 30 chars and that audit tables have been created/updated and do not contain FKs on entities. -->
- [ ] Tested with Oracle/PostgreSQL
- [ ] Export updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-<!-- insert issue number -->
