### PR TITLE
Version: Change naming mechanism for editor

### DIFF
--- a/src/main/java/org/damap/base/domain/listener/DamapRevisionListener.java
+++ b/src/main/java/org/damap/base/domain/listener/DamapRevisionListener.java
@@ -16,7 +16,7 @@ public class DamapRevisionListener implements RevisionListener {
     if (revisionEntity instanceof DamapRevisionEntity) {
 
       final String userId = CDI.current().select(SecurityService.class).get().getUserId();
-      final String username = CDI.current().select(SecurityService.class).get().getUserName();
+      final String username = CDI.current().select(SecurityService.class).get().getDisplayName();
       ((DamapRevisionEntity) revisionEntity).setChangedById(userId);
       ((DamapRevisionEntity) revisionEntity).setChangedBy(username);
     }

--- a/src/main/java/org/damap/base/security/SecurityService.java
+++ b/src/main/java/org/damap/base/security/SecurityService.java
@@ -55,6 +55,33 @@ public class SecurityService {
     return ((OidcJwtCallerPrincipal) principal).getName();
   }
 
+  public String getDisplayName() {
+    final Principal principal = securityIdentity.getPrincipal();
+    if (!(principal instanceof OidcJwtCallerPrincipal)) {
+      return null;
+    }
+
+    OidcJwtCallerPrincipal oidcPrincipal = (OidcJwtCallerPrincipal) principal;
+
+    String name = getClaimValueAsString(oidcPrincipal, "name");
+    if (name != null) {
+      return name;
+    }
+
+    String firstName = getClaimValueAsString(oidcPrincipal, "given_name");
+    String lastName = getClaimValueAsString(oidcPrincipal, "family_name");
+    if (firstName != null && lastName != null) {
+      return firstName + " " + lastName;
+    }
+
+    return getClaimValueAsString(oidcPrincipal, "email");
+  }
+
+  private String getClaimValueAsString(OidcJwtCallerPrincipal oidcPrincipal, String claimKey) {
+    Object claimValue = oidcPrincipal.getClaims().getClaimValue(claimKey);
+    return claimValue != null ? claimValue.toString() : null;
+  }
+
   /**
    * isAdmin.
    *

--- a/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.3.1_1.yaml
+++ b/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.3.1_1.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: 18
+      author: Geoffrey Karnbach
+      changes:
+        - update:
+            tableName: revinfo
+            columns:
+              - column:
+                  name: changed_by
+                  value: ""
+            where: "id IN (SELECT revision_entity_id FROM dmp_version WHERE revision_entity_id IS NOT NULL)"

--- a/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.x.yaml
+++ b/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.x.yaml
@@ -15,3 +15,5 @@ databaseChangeLog:
       file: org/damap/base/db/changeLog-4.x/changeLog-4.3.0_2.yaml
   - include:
       file: org/damap/base/db/changeLog-4.x/changeLog-4.3.0_3.yaml
+  - include:
+      file: org/damap/base/db/changeLog-4.x/changeLog-4.3.1_1.yaml


### PR DESCRIPTION

## Description
Bugfix

#### What does this PR do?
Add new method to security service with claims on JWT to use correct display name for editor in the version view.


closes GH-291
