### PR TITLE
DMP Filename handling

### DIFF
--- a/src/main/java/org/damap/base/rest/dmp/service/DmpService.java
+++ b/src/main/java/org/damap/base/rest/dmp/service/DmpService.java
@@ -241,27 +241,19 @@ public class DmpService {
         }
       }
 
-      // This condition is met if:
-      // - no project (dmp.getProject() == null).
-      // - a project that contains neither an acronym nor a title
-      // - if dmp.getTitle() is available, we use it directly.
-      if (namePart == null && dmp.getTitle() != null) {
+      if (dmp.getTitle() != null && !dmp.getTitle().trim().isEmpty()) {
         namePart = dmp.getTitle();
         usePrefixAndSuffix = false;
       }
     }
 
     String finalName;
-    if (namePart != null) {
-      if (usePrefixAndSuffix) {
-        finalName = "DMP_" + namePart + "_" + formattedDate;
-      } else {
-        finalName = namePart;
-      }
+    if (namePart != null && !namePart.trim().isEmpty()) {
+      finalName = usePrefixAndSuffix ? "DMP_" + namePart + "_" + formattedDate : namePart;
     } else {
-      // Fallback to default if no namePart could be determined from DMP or Project
       finalName = "DMP_" + id + "_" + formattedDate;
     }
+
     return finalName.replaceAll("[\"',\s]+", "_");
   }
 

--- a/src/main/java/org/damap/base/rest/dmp/service/DmpService.java
+++ b/src/main/java/org/damap/base/rest/dmp/service/DmpService.java
@@ -16,6 +16,7 @@ import org.damap.base.enums.EIdentifierType;
 import org.damap.base.repo.AccessRepo;
 import org.damap.base.repo.DmpRepo;
 import org.damap.base.rest.dmp.domain.*;
+import org.damap.base.rest.dmp.domain.ProjectDO;
 import org.damap.base.rest.dmp.mapper.ContributorDOMapper;
 import org.damap.base.rest.dmp.mapper.DmpDOMapper;
 import org.damap.base.rest.dmp.mapper.DmpListItemDOMapper;
@@ -212,37 +213,56 @@ public class DmpService {
   }
 
   /**
-   * getDefaultFileName.
+   * Generates a default filename for a DMP based in the info. Default format: "DMP_[id]_[date]"
    *
-   * @param id a long
-   * @return a {@link java.lang.String} object
+   * @param id The ID of the DMP
+   * @return A sanitized filename string
    */
   public String getDefaultFileName(long id) {
     Date date = new Date();
     SimpleDateFormat formatter = new SimpleDateFormat("yyyyMMdd");
+    String formattedDate = formatter.format(date);
 
-    String filename = "My Data Management Plan";
+    String namePart = null;
+    boolean usePrefixAndSuffix = true;
 
     Dmp dmp = dmpRepo.findById(id);
+
     if (dmp != null) {
       if (dmp.getProject() != null) {
-        if (dmp.getProject().getUniversityId() != null
-            && projectService.read(dmp.getProject().getUniversityId()) != null) {
-          filename =
-              "DMP_"
-                  + projectService.read(dmp.getProject().getUniversityId()).getAcronym()
-                  + "_"
-                  + formatter.format(date);
-        } else if (dmp.getProject().getTitle() != null)
-          filename = "DMP_" + dmp.getProject().getTitle() + "_" + formatter.format(date);
-      } else {
-        if (dmp.getTitle() != null) filename = dmp.getTitle();
+        String universityId = dmp.getProject().getUniversityId();
+        ProjectDO universityProject =
+            (universityId != null) ? projectService.read(universityId) : null;
+
+        if (universityProject != null && universityProject.getAcronym() != null) {
+          namePart = universityProject.getAcronym();
+        } else if (dmp.getProject().getTitle() != null) {
+          namePart = dmp.getProject().getTitle();
+        }
+      }
+
+      // This condition is met if:
+      // - no project (dmp.getProject() == null).
+      // - a project that contains neither an acronym nor a title
+      // - if dmp.getTitle() is available, we use it directly.
+      if (namePart == null && dmp.getTitle() != null) {
+        namePart = dmp.getTitle();
+        usePrefixAndSuffix = false;
       }
     }
 
-    filename = filename.replaceAll("[\"',\\s]+", "_");
-
-    return filename;
+    String finalName;
+    if (namePart != null) {
+      if (usePrefixAndSuffix) {
+        finalName = "DMP_" + namePart + "_" + formattedDate;
+      } else {
+        finalName = namePart;
+      }
+    } else {
+      // Fallback to default if no namePart could be determined from DMP or Project
+      finalName = "DMP_" + id + "_" + formattedDate;
+    }
+    return finalName.replaceAll("[\"',\s]+", "_");
   }
 
   /**

--- a/src/main/java/org/damap/base/rest/dmp/service/DmpService.java
+++ b/src/main/java/org/damap/base/rest/dmp/service/DmpService.java
@@ -16,7 +16,6 @@ import org.damap.base.enums.EIdentifierType;
 import org.damap.base.repo.AccessRepo;
 import org.damap.base.repo.DmpRepo;
 import org.damap.base.rest.dmp.domain.*;
-import org.damap.base.rest.dmp.domain.ProjectDO;
 import org.damap.base.rest.dmp.mapper.ContributorDOMapper;
 import org.damap.base.rest.dmp.mapper.DmpDOMapper;
 import org.damap.base.rest.dmp.mapper.DmpListItemDOMapper;
@@ -213,48 +212,61 @@ public class DmpService {
   }
 
   /**
-   * Generates a default filename for a DMP based in the info. Default format: "DMP_[id]_[date]"
+   * Default filename for a DMP based on a priority order: DMP Title Project information with prefix
+   * and date Fallback to ID-based name
    *
    * @param id The ID of the DMP
    * @return A sanitized filename string
    */
   public String getDefaultFileName(long id) {
     Date date = new Date();
-    SimpleDateFormat formatter = new SimpleDateFormat("yyyyMMdd");
-    String formattedDate = formatter.format(date);
-
-    String namePart = null;
-    boolean usePrefixAndSuffix = true;
+    String formattedDate = new SimpleDateFormat("yyyyMMdd").format(date);
 
     Dmp dmp = dmpRepo.findById(id);
-
-    if (dmp != null) {
-      if (dmp.getProject() != null) {
-        String universityId = dmp.getProject().getUniversityId();
-        ProjectDO universityProject =
-            (universityId != null) ? projectService.read(universityId) : null;
-
-        if (universityProject != null && universityProject.getAcronym() != null) {
-          namePart = universityProject.getAcronym();
-        } else if (dmp.getProject().getTitle() != null) {
-          namePart = dmp.getProject().getTitle();
-        }
-      }
-
-      if (dmp.getTitle() != null && !dmp.getTitle().trim().isEmpty()) {
-        namePart = dmp.getTitle();
-        usePrefixAndSuffix = false;
-      }
+    if (dmp == null) {
+      return "My Data Management Plan";
     }
 
-    String finalName;
-    if (namePart != null && !namePart.trim().isEmpty()) {
-      finalName = usePrefixAndSuffix ? "DMP_" + namePart + "_" + formattedDate : namePart;
-    } else {
-      finalName = "DMP_" + id + "_" + formattedDate;
+    if (hasDmpTitle(dmp)) {
+      return sanitizeFileName(dmp.getTitle());
     }
 
-    return finalName.replaceAll("[\"',\s]+", "_");
+    String projectName = extractProjectName(dmp);
+    if (projectName != null) {
+      return formatProjectBasedName(projectName, formattedDate);
+    }
+
+    return formatDefaultName(id, formattedDate);
+  }
+
+  private boolean hasDmpTitle(Dmp dmp) {
+    return dmp.getTitle() != null && !dmp.getTitle().trim().isEmpty();
+  }
+
+  private String extractProjectName(Dmp dmp) {
+    if (dmp.getProject() == null) {
+      return null;
+    }
+
+    String universityId = dmp.getProject().getUniversityId();
+    ProjectDO universityProject = (universityId != null) ? projectService.read(universityId) : null;
+
+    if (universityProject != null && universityProject.getAcronym() != null) {
+      return universityProject.getAcronym();
+    }
+    return dmp.getProject().getTitle();
+  }
+
+  private String formatProjectBasedName(String name, String date) {
+    return String.format("DMP_%s_%s", name, date).replaceAll("[\"',\\s]+", "_");
+  }
+
+  private String formatDefaultName(long id, String date) {
+    return String.format("DMP_%d_%s", id, date);
+  }
+
+  private String sanitizeFileName(String name) {
+    return name.replaceAll("[\"',\\s]+", "_");
   }
 
   /**

--- a/src/test/java/org/damap/base/rest/dmp/DmpServiceTest.java
+++ b/src/test/java/org/damap/base/rest/dmp/DmpServiceTest.java
@@ -3,7 +3,14 @@ package org.damap.base.rest.dmp;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
-import java.util.*;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import lombok.extern.java.Log;
 import org.damap.base.TestSetup;
 import org.damap.base.enums.EContributorRole;
@@ -162,5 +169,32 @@ class DmpServiceTest extends TestSetup {
     testDMP.getProject().setAcronym("newAcronym");
     DmpDO updatedDMP = dmpService.update(testDMP);
     Assertions.assertEquals("newAcronym", updatedDMP.getProject().getAcronym());
+  }
+
+  @Test
+  void givenDmpWithValidTitle_whenGettingDefaultFileName_thenShouldUseTitle() {
+    DmpDO dmpWithTitle = new DmpDO();
+    dmpWithTitle.setTitle("Test DMP Title");
+    dmpWithTitle = dmpService.create(dmpWithTitle, "testUser");
+
+    String fileName = dmpService.getDefaultFileName(dmpWithTitle.getId());
+
+    Assertions.assertEquals("Test_DMP_Title", fileName);
+  }
+
+  @Test
+  void givenOldDmpWithNullTitleAndNullProjectTitle_whenGettingDefaultFileName_thenShouldUseDmpId() {
+    DmpDO oldDmp = new DmpDO();
+    oldDmp.setTitle(null);
+    ProjectDO project = new ProjectDO();
+    project.setTitle(null);
+    oldDmp.setProject(project);
+    oldDmp = dmpService.create(oldDmp, "testUser");
+
+    String fileName = dmpService.getDefaultFileName(oldDmp.getId());
+
+    Date date = new Date();
+    SimpleDateFormat formatter = new SimpleDateFormat("yyyyMMdd");
+    Assertions.assertEquals("DMP_" + oldDmp.getId() + "_" + formatter.format(date), fileName);
   }
 }

--- a/src/test/java/org/damap/base/util/TestDOFactory.java
+++ b/src/test/java/org/damap/base/util/TestDOFactory.java
@@ -152,7 +152,7 @@ public class TestDOFactory {
     prepareInternalStorageOption();
 
     final Optional<Dmp> testDmp =
-        dmpRepo.getAll().stream().filter(a -> a.getTitle().equals("TestDmp")).findAny();
+        dmpRepo.getAll().stream().filter(a -> "TestDmp".equals(a.getTitle())).findAny();
     if (testDmp.isPresent()) return DmpDOMapper.mapEntityToDO(testDmp.get(), new DmpDO());
 
     DmpDO newTestDmpDO = new DmpDO();
@@ -313,7 +313,7 @@ public class TestDOFactory {
     StorageDO storage = new StorageDO();
     Optional<InternalStorageTranslation> testInternalStorage =
         internalStorageTranslationRepo.getAllInternalStorageByLanguage("eng").stream()
-            .filter(a -> a.getTitle().equals("Test Storage Title"))
+            .filter(a -> "Test Storage Title".equals(a.getTitle()))
             .findAny();
     testInternalStorage.ifPresent(
         storageTranslation ->
@@ -353,7 +353,7 @@ public class TestDOFactory {
    */
   public DmpDO getOrCreateTestDmpDOEmpty() {
     final Optional<Dmp> testDmp =
-        dmpRepo.getAll().stream().filter(a -> a.getTitle().equals("EmptyTestDmp")).findAny();
+        dmpRepo.getAll().stream().filter(a -> "EmptyTestDmp".equals(a.getTitle())).findAny();
     if (testDmp.isPresent()) return DmpDOMapper.mapEntityToDO(testDmp.get(), new DmpDO());
 
     DmpDO newTestDmpDO = new DmpDO();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
The getDefaultFileName() method in DmpService was not handling null titles consistently, potentially resulting in filenames like "DMP_null_someID" for older DMPs.
Test cases for the getDefaultFileName() method were incomplete, missing scenarios for older DMPs with null titles and special characters

#### What does this PR do?
Always prefix filenames with "DMP_" for consistency
Handle null titles by using the DMP ID as a fallback
Added test case 

#### Breaking changes
<!-- Whether this PR contains breaking changes and which -->

#### Code review focus
<!-- What you want the reviewer to focus on -->

#### Dependencies
<!-- If this PR depends on or requires other/additional (frontend) changes, please list them here -->

### Checks
<!-- Adjust list as necessary -->
<!-- In case of DB changes make sure that names do not exceed 30 chars and that audit tables have been created/updated and do not contain FKs on entities. -->
- [ ] Tested with Oracle/PostgreSQL
- [ ] Export updated
- [ ] Documentation added
- [x] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-350
