### PR TITLE
Liquibase: Fix postgres-only changesets

### DIFF
--- a/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.3.0_3.yaml
+++ b/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.3.0_3.yaml
@@ -2,6 +2,10 @@ databaseChangeLog:
   - changeSet:
       id: 17
       author: Geoffrey Karnbach
+      # This changeset used to include postgres only code
+      # It was removed using validCheckSum, since some systems already deployed the old changeset
+      validCheckSum:
+        - 9:fa58a1e00783e5d2149d37385f306ecc
       changes:
         - createSequence:
             sequenceName: banner_seq
@@ -14,7 +18,6 @@ databaseChangeLog:
               - column:
                   name: id
                   type: BIGINT
-                  defaultValueComputed: "nextval('banner_seq')"
                   constraints:
                     primaryKey: true
                     nullable: false

--- a/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.4.0_1.yaml
+++ b/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.4.0_1.yaml
@@ -2,6 +2,10 @@ databaseChangeLog:
   - changeSet:
       id: 21
       author: Geoffrey Karnbach
+      # This changeset used to include postgres only code
+      # It was removed using validCheckSum, since some systems already deployed the old changeset
+      validCheckSum:
+        - 9:eb65b4b53c688a6b504e5b864e575b5b
       changes:
         - createSequence:
             sequenceName: technical_resource_seq
@@ -14,7 +18,6 @@ databaseChangeLog:
               - column:
                   name: id
                   type: BIGINT
-                  defaultValueComputed: "nextval('technical_resource_seq')"
                   constraints:
                     primaryKey: true
                     nullable: false


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
Bugfix

#### What does this PR do?
Removes the lines `defaultValueComputed: "nextval('technical_resource_seq')"` and `defaultValueComputed: "nextval('banner_seq')"` from the changesets. Their only purpose is to autofill in id values, when the db is manually filled - which is not needed in DAMAP. Hibernate takes care of IDs  using sequences.
This makes it run in oracle, since the postgres-only code is removed.

Since removing the lines changed the hash, I also added [validCheckSum tags](https://docs.liquibase.com/concepts/changelogs/changeset.html#:~:text=SQL%20Format.-,validCheckSum,-Adds%20a%20checksum) and set them to the old hash. This way, the changeset is not executed again in old deployments. The code that was removed is not harmful to them, so nothing changes here. New installations will just execute the new changeset.

closes GH-357
