### PR TITLE
Liquibase: Remove redundant unique constraints on primary key columns

### DIFF
--- a/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.3.0_3.yaml
+++ b/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.3.0_3.yaml
@@ -6,6 +6,7 @@ databaseChangeLog:
       # It was removed using validCheckSum, since some systems already deployed the old changeset
       validCheckSum:
         - 9:fa58a1e00783e5d2149d37385f306ecc
+        - 9:27b12d878aa432defab22ce460bb4d97
       changes:
         - createSequence:
             sequenceName: banner_seq
@@ -21,7 +22,6 @@ databaseChangeLog:
                   constraints:
                     primaryKey: true
                     nullable: false
-                    unique: true
               - column:
                   name: title
                   type: VARCHAR(255)

--- a/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.4.0_1.yaml
+++ b/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.4.0_1.yaml
@@ -6,6 +6,7 @@ databaseChangeLog:
       # It was removed using validCheckSum, since some systems already deployed the old changeset
       validCheckSum:
         - 9:eb65b4b53c688a6b504e5b864e575b5b
+        - 9:ce1361b67db53e5a54079e51ae41d17d
       changes:
         - createSequence:
             sequenceName: technical_resource_seq
@@ -21,7 +22,6 @@ databaseChangeLog:
                   constraints:
                     primaryKey: true
                     nullable: false
-                    unique: true
               - column:
                   name: name
                   type: VARCHAR(255)


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
Bugfix

Removes redunat unique constraints because they crash oracle.
