### PR TITLE
Export: Fix incompatible column number warning

### DIFF
--- a/src/main/java/org/damap/base/conversion/AbstractTemplateExportFunctions.java
+++ b/src/main/java/org/damap/base/conversion/AbstractTemplateExportFunctions.java
@@ -156,19 +156,6 @@ public abstract class AbstractTemplateExportFunctions {
     int numCells = cells.size();
     int numContent = cellContent.size();
 
-    // Log warning if numCells and numContent does not match
-    if (numCells != numContent) {
-      log.warn(
-          String.format(
-              "Table %s\n"
-                  + "Number of provided values for table row does not match number of row cells. num provided/num row cells: %2d/%2d",
-              String.join(
-                  " | ",
-                  table.getRow(0).getTableCells().stream().map(XWPFTableCell::getText).toList()),
-              numContent,
-              numCells));
-    }
-
     // Iterate over min(numCells, numContent) to prevent out of bounds
     for (int i = 0; i < Math.min(numCells, numContent); i++) {
       XWPFTableCell cell = cells.get(i);

--- a/src/main/java/org/damap/base/conversion/AbstractTemplateExportScienceEuropeComponents.java
+++ b/src/main/java/org/damap/base/conversion/AbstractTemplateExportScienceEuropeComponents.java
@@ -1143,8 +1143,8 @@ public abstract class AbstractTemplateExportScienceEuropeComponents
       }
       xwpfTable.removeRow(xwpfTable.getRows().size() - 1);
     } else {
-      // clean row
-      ArrayList<String> emptyContent = new ArrayList<>(Arrays.asList("", "", "", "", "", "", ""));
+      // clean row, the first FWF template table has the additional "description" column
+      ArrayList<String> emptyContent = new ArrayList<>(Collections.nCopies(7, ""));
       insertTableCells(
           xwpfTable, xwpfTable.getRows().get(xwpfTable.getRows().size() - 1), emptyContent);
     }
@@ -1376,8 +1376,7 @@ public abstract class AbstractTemplateExportScienceEuropeComponents
       xwpfTable.removeRow(xwpfTable.getRows().size() - 1);
     } else {
       // clean row
-      ArrayList<String> emptyContent =
-          new ArrayList<String>(Arrays.asList("", "", "", "", "", "", ""));
+      ArrayList<String> emptyContent = new ArrayList<String>(Arrays.asList("", "", "", "", "", ""));
       insertTableCells(
           xwpfTable, xwpfTable.getRows().get(xwpfTable.getRows().size() - 1), emptyContent);
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->
Bugfix
#### What does this PR do?
<!-- Changes introduced by this PR - what happened before, what happens now -->
Fixes the warnings of the form "Number of provided values for table row does not match number of row cells. num provided/num row cells: 7/6"

This had 2 causes:
- For the 1st table (_produced datasets_): the description column is always passed along to fill the table even though only the FWF template actually uses such a column. This does not break functionality (but still leads to the warning) since the minimum of numCells and numContent is taken  (see line 173 in _AbstractTemplateExportFunctions_) as the number of columns to fill, i.e. the minimum of expected and provided column numbers. At first, I tried fixing it with overrides of the composeTableDataAccess method from the abstract _AbstractTemplateExportScienceEuropeComponents_ class in the export classes but this is cumbersome. This solution using instanceof is more elegant, as it simply checks if the _ExportFWFTemplate_ class is instantiated and if so passes along 7 columns instead of 6 (both if there are datasets or if there are none).

- For the 3rd table (_Data publication and access conditions_): if no dataset is specified, an array of 7 empty strings was created but it should  be 6 since that table has 6 columns in all 3 templates.
#### Breaking changes
<!-- Whether this PR contains breaking changes and which -->

closes GH-371<!-- insert issue number -->