### PR TITLE
Fixing container permissions for OpenShift deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,12 @@ jobs:
           distribution: "adopt"
           java-version: 17.0
 
+      - name: Change Maven version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          VERSION=$(echo -n '${{ github.ref_name }}' | sed -e 's$refs/tags/$$' | sed -e 's/v//')
+          sed -i "s/0.0.0-SNAPSHOT/${VERSION}/" pom.xml
+
       - name: Publish to GitHub packages
         run: mvn -B deploy
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,13 +42,11 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 RUN dnf install -y openssl tzdata-java curl ca-certificates ${JAVA_PACKAGE} \
     && dnf clean all -y \
     && mkdir /deployments \
-    && chown 1001 /deployments \
-    && chmod "g+rwX" /deployments \
-    && chown 1001:root /deployments \
     && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
-    && chown 1001 /deployments/run-java.sh \
-    && chmod 540 /deployments/run-java.sh \
-    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security \
+    && chmod 0755 /deployments \
+    && chmod 777 /deployments/run-java.sh \
+    && chown -R 1001:root /deployments
 
 # configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Duser.home=/deployments"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
   damap-be:
     # Since DAMAP containers are publicly available on Github packages one can
     # just pull the latest container image.
-    image: ghcr.io/tuwien-csd/damap-backend:next
+    image: ghcr.io/damap-org/damap-backend:next
     restart: unless-stopped
 
     build:
@@ -28,7 +28,7 @@ services:
   damap-fe:
     # Since DAMAP containers are publicly available on Github packages one can
     # just pull the latest container image.
-    image: ghcr.io/tuwien-csd/damap-frontend:next
+    image: ghcr.io/damap-org/damap-frontend:next
     pull_policy: always
     restart: unless-stopped
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.damap</groupId>
   <artifactId>base</artifactId>
-  <version>4.6.0-SNAPSHOT</version>
+  <version>0.0.0-SNAPSHOT</version>
 
   <name>${project.groupId}:${project.artifactId}</name>
   <description>A tool for machine actionable DMPs.</description>
@@ -21,12 +21,6 @@
   </licenses>
 
   <developers>
-    <developer>
-      <name>David Eckhard</name>
-      <email>david.eckhard@tugraz.at</email>
-      <organization>Graz University of Technology</organization>
-      <organizationUrl>https://www.tugraz.at/</organizationUrl>
-    </developer>
     <developer>
       <name>Valentin Futterer</name>
       <email>valentin.futterer@tuwien.ac.at</email>
@@ -42,9 +36,9 @@
   </developers>
 
   <scm>
-    <url>https://maven.pkg.github.com/tuwien-csd/damap-backend</url>
-    <connection>scm:git:https://github.com/tuwien-csd/damap-backend.git</connection>
-    <developerConnection>scm:git:https://github.com/tuwien-csd/damap-backend.git</developerConnection>
+    <url>https://maven.pkg.github.com/damap-org/damap-backend</url>
+    <connection>scm:git:https://github.com/damap-org/damap-backend.git</connection>
+    <developerConnection>scm:git:https://github.com/damap-org/damap-backend.git</developerConnection>
   </scm>
 
   <properties>


### PR DESCRIPTION
This PR changes the `Dockerfile` to make it possible to run with a different user. This is necessary because OpenShift and hardened Kubernetes clusters typically impose additional restrictions and change the user ID.

Additionally, this PR also includes a change to make releases easier.