### PR TITLE
Build: Add JavaDoc step to mvn verify. Fix javadoc generation issues.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,20 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.7.0</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs-verify</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>${quarkus.platform.version}</version>

--- a/src/main/java/org/damap/base/conversion/AbstractTemplateExportSetup.java
+++ b/src/main/java/org/damap/base/conversion/AbstractTemplateExportSetup.java
@@ -95,7 +95,7 @@ public abstract class AbstractTemplateExportSetup extends AbstractTemplateExport
    * getContributorsByRole.
    *
    * @param contributors a {@link java.util.List} object
-   * @param role a {@link org.damap.base.enums.EContributorRole} object
+   * @param roles a {@link java.util.Set} object
    * @return a {@link java.util.List} object
    */
   protected List<Contributor> getContributorsByRole(

--- a/src/main/resources/org/damap/base/spec/oaf/oaf-common-1.0.xsd
+++ b/src/main/resources/org/damap/base/spec/oaf/oaf-common-1.0.xsd
@@ -221,8 +221,7 @@
 
     <xs:complexType name="relToType">
         <xs:annotation>
-            <xs:documentation>Information about the related entity. <p>The semantics of the
-                relationships is expressed by the attributes class and scheme. </p>
+            <xs:documentation>Information about the related entity. <p>The semantics of the relationships is expressed by the attributes class and scheme. </p>
             </xs:documentation>
         </xs:annotation>
         <xs:simpleContent>


### PR DESCRIPTION
## Description
Build enhancement:

#### What does this PR do?
Now, the javadoc generation step can be run by using the "mvn verify" or "mvn clean verify" targets, for easier catching of issues.
Furthermore, a JavaDoc comment was changed and a linebreak removed of an XSD file.

closes GH-388
