### PR TITLE
Access: Add support for granting and revoking owner rights

### DIFF
--- a/src/main/java/org/damap/base/repo/AccessRepo.java
+++ b/src/main/java/org/damap/base/repo/AccessRepo.java
@@ -12,7 +12,7 @@ import org.damap.base.domain.Dmp;
 public class AccessRepo implements PanacheRepository<Access> {
 
   /**
-   * getAllByUniversityId.
+   * Returns all accesses by the institution/university-specific identifier of a person.
    *
    * @param universityId a {@link java.lang.String} object
    * @return a {@link java.util.List} object

--- a/src/main/java/org/damap/base/repo/AccessRepo.java
+++ b/src/main/java/org/damap/base/repo/AccessRepo.java
@@ -12,12 +12,12 @@ import org.damap.base.domain.Dmp;
 public class AccessRepo implements PanacheRepository<Access> {
 
   /**
-   * getAllDmpByUniversityId.
+   * getAllByUniversityId.
    *
    * @param universityId a {@link java.lang.String} object
    * @return a {@link java.util.List} object
    */
-  public List<Access> getAllDmpByUniversityId(String universityId) {
+  public List<Access> getAllByUniversityId(String universityId) {
     return list(
         "select access from Access access" + " where access.universityId = :universityId ",
         Parameters.with("universityId", universityId));

--- a/src/main/java/org/damap/base/rest/access/service/AccessService.java
+++ b/src/main/java/org/damap/base/rest/access/service/AccessService.java
@@ -97,6 +97,12 @@ public class AccessService {
    */
   @Transactional
   public AccessDO create(AccessDO accessDO) {
+    // There should ever only be one access, so automatically delete the older ones (editing
+    // existing access is not supported)
+    if (accessDO.getId() != null) {
+      accessRepo.deleteById(accessDO.getId());
+    }
+
     Access access = new Access();
     AccessMapper.mapDOtoEntity(accessDO, access, mapperService);
     if (access.getPersonIdentifier() != null) {

--- a/src/main/java/org/damap/base/rest/dmp/service/DmpService.java
+++ b/src/main/java/org/damap/base/rest/dmp/service/DmpService.java
@@ -76,7 +76,7 @@ public class DmpService {
   @Transactional
   public List<DmpListItemDO> getDmpListByPersonId(String personId) {
 
-    List<Access> accessList = accessRepo.getAllDmpByUniversityId(personId);
+    List<Access> accessList = accessRepo.getAllByUniversityId(personId);
 
     List<DmpListItemDO> dmpListItemDOS = new ArrayList<>();
     accessList.forEach(
@@ -112,7 +112,7 @@ public class DmpService {
    */
   @Transactional
   public List<DmpDO> getDmpDOListByPersonId(String personId) {
-    List<Access> accessList = accessRepo.getAllDmpByUniversityId(personId);
+    List<Access> accessList = accessRepo.getAllByUniversityId(personId);
 
     List<DmpDO> dmpDOS = new ArrayList<>();
     accessList.forEach(

--- a/src/main/java/org/damap/base/validation/AccessValidator.java
+++ b/src/main/java/org/damap/base/validation/AccessValidator.java
@@ -36,7 +36,7 @@ public class AccessValidator {
       return true;
     }
 
-    List<Access> accessList = accessRepo.getAllDmpByUniversityId(personId);
+    List<Access> accessList = accessRepo.getAllByUniversityId(personId);
 
     Optional<Access> dmpAccess =
         accessList.stream().filter(access -> access.getDmp().id.equals(dmpId)).findAny();
@@ -56,7 +56,7 @@ public class AccessValidator {
       return true;
     }
 
-    List<Access> accessList = accessRepo.getAllDmpByUniversityId(personId);
+    List<Access> accessList = accessRepo.getAllByUniversityId(personId);
 
     Optional<Access> dmpAccess =
         accessList.stream()
@@ -93,7 +93,7 @@ public class AccessValidator {
       return true;
     }
 
-    List<Access> accessList = accessRepo.getAllDmpByUniversityId(personId);
+    List<Access> accessList = accessRepo.getAllByUniversityId(personId);
 
     Optional<Access> dmpAccess =
         accessList.stream()
@@ -142,9 +142,6 @@ public class AccessValidator {
    * @return a boolean
    */
   public boolean canCreateAccess(AccessDO accessDO) {
-    if (accessDO.getAccess().equals(EFunctionRole.OWNER)) {
-      return false;
-    }
 
     Dmp dmp = dmpRepo.findById(accessDO.getDmpId());
     if (dmp == null) {
@@ -155,15 +152,15 @@ public class AccessValidator {
     boolean hasPermission = securityService.isAdmin();
     if (!hasPermission) {
       List<Access> accessList = accessRepo.getAccessByDmp(dmp);
-      Optional<Access> dmpAccess =
+      // Check if caller is owner
+      Optional<Access> callerOwnerAccess =
           accessList.stream()
               .filter(
                   access ->
                       access.getUniversityId().equals(securityService.getUserId())
-                          && (access.getRole().equals(EFunctionRole.EDITOR)
-                              || access.getRole().equals(EFunctionRole.OWNER)))
+                          && access.getRole().equals(EFunctionRole.OWNER))
               .findAny();
-      hasPermission = dmpAccess.isPresent();
+      hasPermission = callerOwnerAccess.isPresent();
     }
 
     return canGetAccess(accessDO) && hasPermission;
@@ -176,33 +173,38 @@ public class AccessValidator {
    * @return a boolean
    */
   public boolean canDeleteAccess(long id) {
-    Access access = accessRepo.findById(id);
-
-    // Non-existing access can be deleted (idempotence)
-    if (access == null) {
-      return true;
-    }
-
-    // Can't delete owner access
-    if (access.getRole().equals(EFunctionRole.OWNER)) {
-      return false;
-    }
+    Access accessToDelete = accessRepo.findById(id);
 
     // Check if user has permission to delete access
     if (securityService.isAdmin()) {
       return true;
     }
-    List<Access> accessList = accessRepo.getAllDmpByUniversityId(securityService.getUserId());
-    Optional<Access> dmpAccess =
-        accessList.stream()
-            .filter(
-                a ->
-                    a.getDmp().id.equals(access.getDmp().id)
-                        && (a.getRole().equals(EFunctionRole.EDITOR)
-                            || a.getRole().equals(EFunctionRole.OWNER)))
-            .findAny();
 
-    return dmpAccess.isPresent();
+    // Non-existing access can be deleted (idempotence)
+    if (accessToDelete == null) {
+      return true;
+    }
+
+    List<Access> accessForDmp = accessRepo.getAccessByDmp(accessToDelete.getDmp());
+
+    List<EFunctionRole> callerAccessRoles =
+        accessForDmp.stream()
+            .filter(a -> a.getUniversityId().equals(securityService.getUserId()))
+            .map(Access::getRole)
+            .toList();
+
+    // Only owners can delete access
+    if (!callerAccessRoles.contains(EFunctionRole.OWNER)) {
+      return false;
+    }
+
+    // There has to be one owner always
+    if (accessToDelete.getRole().equals(EFunctionRole.OWNER)) {
+      return accessForDmp.stream().filter(a -> a.getRole() == EFunctionRole.OWNER).limit(2).count()
+          >= 2;
+    }
+
+    return true;
   }
 
   // Can the selected user be given access to this dmp

--- a/src/main/java/org/damap/base/validation/AccessValidator.java
+++ b/src/main/java/org/damap/base/validation/AccessValidator.java
@@ -128,8 +128,7 @@ public class AccessValidator {
             .filter(
                 access ->
                     access.getUniversityId().equals(securityService.getUserId())
-                        && (access.getRole().equals(EFunctionRole.EDITOR)
-                            || access.getRole().equals(EFunctionRole.OWNER)))
+                        && (access.getRole().equals(EFunctionRole.OWNER)))
             .findAny();
 
     return dmpAccess.isPresent();

--- a/src/test/java/org/damap/base/validation/AccessValidatorTest.java
+++ b/src/test/java/org/damap/base/validation/AccessValidatorTest.java
@@ -32,9 +32,9 @@ class AccessValidatorTest {
   @BeforeEach
   public void setup() {
     Mockito.when(securityService.isAdmin()).thenReturn(false);
-    Mockito.when(accessRepo.getAllDmpByUniversityId(ownerId)).thenReturn(getAccessListOwner());
-    Mockito.when(accessRepo.getAllDmpByUniversityId(editorId)).thenReturn(getAccessListEditor());
-    Mockito.when(accessRepo.getAllDmpByUniversityId(guestId)).thenReturn(getAccessListGuest());
+    Mockito.when(accessRepo.getAllByUniversityId(ownerId)).thenReturn(getAccessListOwner());
+    Mockito.when(accessRepo.getAllByUniversityId(editorId)).thenReturn(getAccessListEditor());
+    Mockito.when(accessRepo.getAllByUniversityId(guestId)).thenReturn(getAccessListGuest());
   }
 
   @Test


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
 Feature

#### What does this PR do?
- When creating an access, old accesses for the user are automatically deleted, to avoid having multiple accesses floating around (there was not patch/put for access).
- When deleting accesses, it now makes sure there is always at least one owner left after deleting.
- Now, only the admin or owner of a DMP can view and interact with its accesses.

#### Code review focus
Security aspects. The surrounding code was not perfect and i refrained from a lot of otherwise necesary refactoring to save on time- this will be tackled on a later date.

#### Dependencies
https://github.com/damap-org/damap-frontend/issues/474

closes GH-390
