### PR TITLE
Updating Maven Central to the Sonatype Publishing API

### DIFF
--- a/.github/workflows/release-maven.yml
+++ b/.github/workflows/release-maven.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           distribution: "adopt"
           java-version: 17.0
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
   <distributionManagement>
     <repository>
       <id>github</id>
-      <name>CSD Github</name>
+      <name>GitHub</name>
       <url>https://maven.pkg.github.com/damap-org/damap-backend</url>
     </repository>
   </distributionManagement>
@@ -477,14 +477,14 @@
             </executions>
           </plugin>
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.7.0</version>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.8.0</version>
             <extensions>true</extensions>
             <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
+              <waitUntil>published</waitUntil>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
This change switches the Maven Central publishing to use the [Sonatype publishing API](https://central.sonatype.org/publish/publish-portal-maven/#publishing) instead of the now-deprecated OSSRH method which doesn't work anymore. (See https://central.sonatype.org/pages/ossrh-eol/ for details.)

