### PR TITLE
Datasource environment variable: Revert unnecessary name change

### DIFF
--- a/docker/docker-compose.oracle.yaml
+++ b/docker/docker-compose.oracle.yaml
@@ -14,7 +14,7 @@ services:
       DAMAP_DATASOURCE_URL: "jdbc:oracle:thin:@damap-db:1521/FREEPDB1"
       DAMAP_DATASOURCE_DIALECT: "org.hibernate.dialect.OracleDialect"
       DAMAP_DATASOURCE_DRIVER: "oracle.jdbc.driver.OracleDriver"
-      DAMAP_DATABASE_DB_KIND: "oracle"
+      DAMAP_DATASOURCE_DB_KIND: "oracle"
       DAMAP_DATASOURCE_USERNAME: "damap"
       DAMAP_DATASOURCE_PASSWORD: "pw4damap"
     depends_on:

--- a/docker/docker-compose.postgres.yaml
+++ b/docker/docker-compose.postgres.yaml
@@ -12,7 +12,7 @@ services:
     environment:
       DAMAP_TITLE: "DAMAP Tool"
       DAMAP_DATASOURCE_URL: "jdbc:postgresql://damap-db:5432/damap"
-      DAMAP_DATABASE_DB_KIND: "postgresql"
+      DAMAP_DATASOURCE_DB_KIND: "postgresql"
       DAMAP_DATASOURCE_USERNAME: "damap"
       DAMAP_DATASOURCE_PASSWORD: "pw4damap"
     depends_on:

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 
-db_kind="${DAMAP_DATABASE_DB_KIND:-postgresql}"
+db_kind="${DAMAP_DATASOURCE_DB_KIND:-postgresql}"
 marker_file=".db_kind"
 
 # Check if reaugmentation is needed.

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,8 +22,9 @@ damap:
     user: 'personID'
   datasource:
     url: ${DAMAP_DATASOURCE_URL:jdbc:postgresql://damap-db:5432/damap}
-    db-kind: ${DAMAP_DATABASE_DB_KIND:postgresql}
+    db-kind: ${DAMAP_DATASOURCE_DB_KIND:postgresql}
     driver: ${DAMAP_DATASOURCE_DRIVER:org.postgresql.Driver}
+
     username: ${DAMAP_DATASOURCE_USERNAME:damap}
     password: ${DAMAP_DATASOURCE_PASSWORD:pw4damap}
     dialect: ${DAMAP_DATASOURCE_DIALECT:org.hibernate.dialect.PostgreSQLDialect}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
Refactoring

#### What does this PR do?
Switch the name from DATABASE back to DATASOURCE to stay consistent with the naming scheme.

closes GH-423
