### PR TITLE
Generate sources package by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,8 @@ jobs:
         with:
           distribution: "adopt"
           java-version: 17.0
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: GPG_PASSPHRASE
 
       - name: Change Maven version
         if: startsWith(github.ref, 'refs/tags/')
@@ -39,7 +41,7 @@ jobs:
           sed -i "s/0.0.0-SNAPSHOT/${VERSION}/" pom.xml
 
       - name: Publish to GitHub packages
-        run: mvn -B deploy
+        run: mvn --batch-mode -P deploy-github-repository deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/pom.xml
+++ b/pom.xml
@@ -376,6 +376,20 @@
           </execution>
         </executions>
       </plugin>
+      <!-- Generate <package>-sources.jar for deployment -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.3.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <profiles>
@@ -437,37 +451,31 @@
     </profile>
 
     <profile>
+      <id>deploy-github-repository</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.2.4</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <id>deploy-mvn-repository</id>
       <build>
         <plugins>
-          <!-- Generate <package>-sources.jar for deployment -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-source-plugin</artifactId>
-            <version>3.3.1</version>
-            <executions>
-              <execution>
-                <id>attach-sources</id>
-                <goals>
-                  <goal>jar-no-fork</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <!-- Generate <package>-javadoc.jar for deployment -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.7.0</version>
-            <executions>
-              <execution>
-                <id>attach-javadocs</id>
-                <goals>
-                  <goal>jar</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>


### PR DESCRIPTION
This PR changes the pom.xml to generate the sources jar by default. This is useful in case we need to manually create Maven Central artifacts.