### PR TITLE
lth/Vd/407 make frontend customizable with config api

### DIFF
--- a/docker/example.env
+++ b/docker/example.env
@@ -60,7 +60,7 @@ DAMAP_AUTH_AFFILIATIONS_CLAIM=affiliation
 # Role name used to identify DAMAP super admins
 # If DAMAP is locally deployed and the variable is not set to damap-super-admin, ADMIN_ROLE constant in the
 # DefaultProfile test profile needs to be changed accordingly, otherwise the tests fail
-DAMAP_AUTH_ADMIN_ROLE_NAME='DAMAP ADMIN'
+DAMAP_AUTH_ADMIN_ROLE_NAME='Damap Admin'
 
 ## =====================
 ## Databases

--- a/src/main/java/org/damap/base/domain/ColorTheme.java
+++ b/src/main/java/org/damap/base/domain/ColorTheme.java
@@ -1,0 +1,27 @@
+package org.damap.base.domain;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.damap.base.domain.converter.MapToJsonConverter;
+import org.hibernate.Length;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "color_theme")
+public class ColorTheme extends PanacheEntity {
+
+  @Column(name = "exact_colors", nullable = false)
+  private boolean exactColors;
+
+  @Convert(converter = MapToJsonConverter.class)
+  @Column(name = "colors", length = Length.LONG32)
+  private Map<String, String> colors = new HashMap<>();
+}

--- a/src/main/java/org/damap/base/domain/Image.java
+++ b/src/main/java/org/damap/base/domain/Image.java
@@ -1,0 +1,38 @@
+package org.damap.base.domain;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Basic;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@EqualsAndHashCode(
+    callSuper = true,
+    exclude = {"data"})
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "image")
+public class Image extends PanacheEntity {
+
+  @Column(name = "image_key", nullable = false, unique = true)
+  private String imageKey;
+
+  @Lob
+  @Basic(fetch = FetchType.LAZY)
+  @Column(name = "data", nullable = false)
+  private byte[] data;
+
+  @Column(name = "filesize", nullable = false)
+  private Long filesize; // in bytes
+
+  @Column(name = "mime_type", nullable = false)
+  private String mimeType;
+}

--- a/src/main/java/org/damap/base/domain/RecommendedRepository.java
+++ b/src/main/java/org/damap/base/domain/RecommendedRepository.java
@@ -1,0 +1,22 @@
+package org.damap.base.domain;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@Entity
+@EqualsAndHashCode(callSuper = true)
+@Table(name = "recommended_repository")
+public class RecommendedRepository extends PanacheEntity {
+
+  @NotBlank
+  @Size(max = 255)
+  @Column(name = "repository_id", nullable = false, unique = true)
+  private String repositoryId;
+}

--- a/src/main/java/org/damap/base/domain/converter/MapToJsonConverter.java
+++ b/src/main/java/org/damap/base/domain/converter/MapToJsonConverter.java
@@ -1,0 +1,35 @@
+package org.damap.base.domain.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+@Converter(autoApply = false)
+public class MapToJsonConverter implements AttributeConverter<Map<String, String>, String> {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Override
+  public String convertToDatabaseColumn(Map<String, String> attribute) {
+    if (attribute == null) return null;
+    try {
+      return MAPPER.writeValueAsString(attribute);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Could not serialize map to string", e);
+    }
+  }
+
+  @Override
+  public Map<String, String> convertToEntityAttribute(String dbData) {
+    if (dbData == null || dbData.isEmpty()) return Collections.emptyMap();
+    try {
+      return MAPPER.readValue(
+          dbData, MAPPER.getTypeFactory().constructMapType(Map.class, String.class, String.class));
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Could not deserialize string to map", e);
+    }
+  }
+}

--- a/src/main/java/org/damap/base/r3data/RepositoriesService.java
+++ b/src/main/java/org/damap/base/r3data/RepositoriesService.java
@@ -1,17 +1,17 @@
 package org.damap.base.r3data;
 
 import io.quarkus.cache.CacheResult;
+import io.quarkus.panache.common.Sort;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.MultivaluedMap;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import lombok.extern.jbosslog.JBossLog;
+import org.damap.base.domain.RecommendedRepository;
 import org.damap.base.enums.EIdentifierType;
 import org.damap.base.r3data.dto.RepositoryDetails;
 import org.damap.base.r3data.mapper.RepositoryMapper;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.re3data.schema._2_2.Re3Data;
 
@@ -21,9 +21,6 @@ import org.re3data.schema._2_2.Re3Data;
 public class RepositoriesService {
 
   @Inject @RestClient RepositoriesRemoteResource repositoriesRemoteResource;
-
-  @ConfigProperty(name = "damap.repositories.recommendation")
-  Optional<String[]> repositoriesRecommendation;
 
   /**
    * getAll.
@@ -40,24 +37,24 @@ public class RepositoriesService {
    *
    * @return a {@link java.util.List} object
    */
-  @CacheResult(cacheName = "recommendedRepositories")
   public List<RepositoryDetails> getRecommended() {
-    List<RepositoryDetails> recommendedRepositories = new ArrayList<>();
-    if (repositoriesRecommendation.isEmpty()) {
-      return recommendedRepositories;
-    }
+    List<RecommendedRepository> recommendedRepositories =
+        RecommendedRepository.listAll(Sort.by("id").ascending());
+    List<RepositoryDetails> recommendedRepositoryDetails = new ArrayList<>();
 
-    for (String id : repositoriesRecommendation.get()) {
-      if (id.startsWith("r3d")) {
-        try {
-          Re3Data repo = this.getById(id);
-          recommendedRepositories.add(RepositoryMapper.mapToRepositoryDetails(repo, id));
-        } catch (Exception e) {
-          log.infov("Failed to retrieve repository for ID {0}, error: {1}", id, e.getMessage());
-        }
+    for (RecommendedRepository recommendedRepository : recommendedRepositories) {
+      String repositoryId = recommendedRepository.getRepositoryId();
+
+      try {
+        Re3Data repo = this.getById(repositoryId);
+        RepositoryDetails details = RepositoryMapper.mapToRepositoryDetails(repo, repositoryId);
+        recommendedRepositoryDetails.add(details);
+      } catch (Exception e) {
+        log.infov(
+            "Failed to retrieve repository for ID {0}, error: {1}", repositoryId, e.getMessage());
       }
     }
-    return recommendedRepositories;
+    return recommendedRepositoryDetails;
   }
 
   /**

--- a/src/main/java/org/damap/base/rest/AdminResource.java
+++ b/src/main/java/org/damap/base/rest/AdminResource.java
@@ -4,11 +4,29 @@ import io.quarkus.security.Authenticated;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
-import jakarta.ws.rs.*;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import java.util.List;
 import lombok.extern.jbosslog.JBossLog;
+import org.damap.base.domain.ColorTheme;
+import org.damap.base.domain.Image;
+import org.damap.base.domain.RecommendedRepository;
 import org.damap.base.rest.admin.domain.BannerDO;
+import org.damap.base.rest.admin.domain.RecommendedRepositoryDO;
 import org.damap.base.rest.admin.service.AdminService;
+import org.damap.base.rest.admin.service.RecommendedRepositoryService;
+import org.damap.base.rest.theme.service.ColorThemeService;
+import org.damap.base.rest.theme.service.ImageThemeService;
+import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.resteasy.reactive.RestPath;
+import org.jboss.resteasy.reactive.multipart.FileUpload;
 
 /** AdminResource class. */
 @Path("/api/admin")
@@ -18,11 +36,14 @@ import org.damap.base.rest.admin.service.AdminService;
 public class AdminResource {
 
   @Inject AdminService adminService;
+  @Inject RecommendedRepositoryService recommendedRepositoryService;
+  @Inject ColorThemeService colorThemeService;
+  @Inject ImageThemeService imageThemeService;
 
   @GET
   @Path("/banner")
   public BannerDO getAppBanner() {
-    log.info("GET /admin/banner");
+    log.info("Retrieving application banner");
     return this.adminService.getAppBanner();
   }
 
@@ -30,7 +51,7 @@ public class AdminResource {
   @Path("/banner")
   @RolesAllowed("${damap.auth.admin-role-name}")
   public BannerDO createAppBanner(@Valid BannerDO bannerDO) {
-    log.info("POST /admin/banner");
+    log.info("Creating new application banner");
     log.info(bannerDO);
     return this.adminService.createAppBanner(bannerDO);
   }
@@ -39,7 +60,7 @@ public class AdminResource {
   @Path("/banner")
   @RolesAllowed("${damap.auth.admin-role-name}")
   public BannerDO updateAppBanner(@Valid BannerDO bannerDO) {
-    log.info("PUT /admin/banner");
+    log.info("Updating application banner");
     log.info(bannerDO);
     return this.adminService.updateAppBanner(bannerDO);
   }
@@ -48,7 +69,71 @@ public class AdminResource {
   @Path("/banner")
   @RolesAllowed("${damap.auth.admin-role-name}")
   public void deleteAppBanner() {
-    log.info("DELETE /admin/banner");
+    log.info("Deleting application banner");
     this.adminService.deleteAppBanner();
+  }
+
+  @GET
+  @Path("/color-theme")
+  @RolesAllowed("${damap.auth.admin-role-name}")
+  public ColorTheme getColorTheme() {
+    log.info("Retrieving color theme configuration");
+    return this.colorThemeService.getTheme();
+  }
+
+  @PUT
+  @Path("/color-theme")
+  @RolesAllowed("${damap.auth.admin-role-name}")
+  public ColorTheme uploadColorTheme(ColorTheme colorTheme) {
+    log.info("Updating color theme configuration");
+    return colorThemeService.uploadTheme(colorTheme);
+  }
+
+  @PUT
+  @Path("/image-theme")
+  @RolesAllowed("${damap.auth.admin-role-name}")
+  @Consumes(MediaType.MULTIPART_FORM_DATA)
+  public Image uploadImage(
+      @RestForm("imageKey") String imageKey, @RestForm("file") FileUpload file) {
+    log.info("Updating image with key: " + imageKey);
+    return imageThemeService.uploadImage(imageKey, file);
+  }
+
+  @DELETE
+  @Path("/image-theme")
+  @RolesAllowed("${damap.auth.admin-role-name}")
+  public void deleteImage(@QueryParam("imageKey") String imageKey) {
+    log.info("Deleting image with key: " + imageKey);
+    imageThemeService.deleteImage(imageKey);
+  }
+
+  @GET
+  @Path("/recommended-repositories")
+  @RolesAllowed("${damap.auth.admin-role-name}")
+  public List<RecommendedRepositoryDO> getRecommendedRepositories() {
+    log.info("Retrieving all recommended repositories");
+    return this.recommendedRepositoryService.getRecommendedRepositoriesWithNames();
+  }
+
+  @POST
+  @Path("/recommended-repositories")
+  @RolesAllowed("${damap.auth.admin-role-name}")
+  public RecommendedRepositoryDO createRecommendedRepository(
+      @Valid RecommendedRepositoryDO recommendedRepositoryDO) {
+    log.info("Creating new recommended repository: " + recommendedRepositoryDO.getRepositoryId());
+    RecommendedRepository recommendedRepository = new RecommendedRepository();
+    recommendedRepository.setRepositoryId(recommendedRepositoryDO.getRepositoryId());
+    RecommendedRepository created =
+        this.recommendedRepositoryService.createRecommendedRepository(recommendedRepository);
+    recommendedRepositoryDO.setId(created.id);
+    return recommendedRepositoryDO;
+  }
+
+  @DELETE
+  @Path("/recommended-repositories/{id}")
+  @RolesAllowed("${damap.auth.admin-role-name}")
+  public void deleteRecommendedRepository(@RestPath Long id) {
+    log.info("Deleting recommended repository with id: " + id);
+    this.recommendedRepositoryService.deleteRecommendedRepository(id);
   }
 }

--- a/src/main/java/org/damap/base/rest/ConfigResource.java
+++ b/src/main/java/org/damap/base/rest/ConfigResource.java
@@ -1,15 +1,21 @@
 package org.damap.base.rest;
 
 import jakarta.annotation.security.PermitAll;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import java.net.URL;
+import java.util.List;
 import java.util.Optional;
 import lombok.extern.jbosslog.JBossLog;
+import org.damap.base.domain.ColorTheme;
+import org.damap.base.domain.Image;
 import org.damap.base.rest.config.domain.ConfigDO;
 import org.damap.base.rest.config.domain.PersonServiceConfigurations;
+import org.damap.base.rest.theme.service.ColorThemeService;
+import org.damap.base.rest.theme.service.ImageThemeService;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 /** ConfigResource class. */
@@ -66,6 +72,10 @@ public class ConfigResource {
   @ConfigProperty(name = "damap.title", defaultValue = "DAMAP Tool")
   String appTitle;
 
+  @Inject ColorThemeService colorThemeService;
+
+  @Inject ImageThemeService imageThemeService;
+
   /**
    * config.
    *
@@ -91,6 +101,12 @@ public class ConfigResource {
     configDO.setFitsServiceAvailable(getFitsServiceAvailability());
     configDO.setLivePreviewAvailable(getGotenbergServiceAvailability());
     configDO.setEthicalReportEnabled(ethicalReportEnabled);
+
+    ColorTheme colorTheme = colorThemeService.getTheme();
+    configDO.setColorTheme(colorTheme);
+
+    List<Image> images = imageThemeService.getImages();
+    configDO.setImages(images);
 
     return configDO;
   }

--- a/src/main/java/org/damap/base/rest/admin/domain/RecommendedRepositoryDO.java
+++ b/src/main/java/org/damap/base/rest/admin/domain/RecommendedRepositoryDO.java
@@ -1,0 +1,10 @@
+package org.damap.base.rest.admin.domain;
+
+import lombok.Data;
+
+@Data
+public class RecommendedRepositoryDO {
+  private Long id;
+  private String repositoryId;
+  private String name;
+}

--- a/src/main/java/org/damap/base/rest/admin/service/AdminService.java
+++ b/src/main/java/org/damap/base/rest/admin/service/AdminService.java
@@ -3,12 +3,10 @@ package org.damap.base.rest.admin.service;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
-import java.util.*;
 import lombok.extern.jbosslog.JBossLog;
 import org.damap.base.domain.Banner;
 import org.damap.base.rest.admin.domain.BannerDO;
 import org.damap.base.rest.admin.mapper.BannerDOMapper;
-import org.damap.base.rest.dmp.mapper.*;
 
 @ApplicationScoped
 @JBossLog

--- a/src/main/java/org/damap/base/rest/admin/service/RecommendedRepositoryService.java
+++ b/src/main/java/org/damap/base/rest/admin/service/RecommendedRepositoryService.java
@@ -1,0 +1,103 @@
+package org.damap.base.rest.admin.service;
+
+import io.quarkus.panache.common.Sort;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ClientErrorException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.jbosslog.JBossLog;
+import org.damap.base.domain.RecommendedRepository;
+import org.damap.base.r3data.RepositoriesService;
+import org.damap.base.rest.admin.domain.RecommendedRepositoryDO;
+import org.re3data.schema._2_2.Re3Data;
+
+@ApplicationScoped
+@JBossLog
+public class RecommendedRepositoryService {
+
+  @Inject RepositoriesService repositoriesService;
+
+  private boolean isValidRepositoryId(String repositoryId) {
+    if (repositoryId == null) {
+      return false;
+    }
+    if (!repositoryId.matches("^r3d\\d{6,}$")) { // not the official pattern
+      return false;
+    }
+    try {
+      repositoriesService.getById(repositoryId);
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  public List<RecommendedRepositoryDO> getRecommendedRepositoriesWithNames() {
+    List<RecommendedRepository> recommendedRepositories =
+        RecommendedRepository.listAll(Sort.by("id").ascending());
+    List<RecommendedRepositoryDO> result = new ArrayList<>();
+
+    for (RecommendedRepository repo : recommendedRepositories) {
+      RecommendedRepositoryDO dto = new RecommendedRepositoryDO();
+      dto.setId(repo.id);
+      dto.setRepositoryId(repo.getRepositoryId());
+
+      try {
+        Re3Data re3Data = repositoriesService.getById(repo.getRepositoryId());
+        if (!re3Data.getRepository().isEmpty()) {
+          dto.setName(re3Data.getRepository().get(0).getRepositoryName().getValue());
+        }
+      } catch (Exception e) {
+        log.infov(
+            "Failed to retrieve repository name for ID {0}, error: {1}",
+            repo.getRepositoryId(), e.getMessage());
+      }
+
+      result.add(dto);
+    }
+
+    return result;
+  }
+
+  @Transactional
+  public RecommendedRepository createRecommendedRepository(
+      @Valid RecommendedRepository recommendedRepository) {
+    RecommendedRepository existing =
+        RecommendedRepository.find("repositoryId = ?1", recommendedRepository.getRepositoryId())
+            .firstResult();
+
+    if (existing != null) {
+      throw new ClientErrorException(
+          "Repository with repository ID '"
+              + recommendedRepository.getRepositoryId()
+              + "' already exists",
+          Response.Status.CONFLICT);
+    }
+
+    // validate and only allow via Re3Data IDs
+    if (!isValidRepositoryId(recommendedRepository.getRepositoryId())) {
+      throw new BadRequestException(
+          "Invalid or unknown Re3Data repository ID: " + recommendedRepository.getRepositoryId());
+    }
+
+    recommendedRepository.persist();
+
+    return recommendedRepository;
+  }
+
+  @Transactional
+  public void deleteRecommendedRepository(Long id) {
+    RecommendedRepository repository = RecommendedRepository.findById(id);
+    if (repository == null) {
+      throw new NotFoundException("Repository with database ID '" + id + "' does not exist");
+    }
+
+    repository.delete();
+  }
+}

--- a/src/main/java/org/damap/base/rest/config/domain/ConfigDO.java
+++ b/src/main/java/org/damap/base/rest/config/domain/ConfigDO.java
@@ -3,6 +3,8 @@ package org.damap.base.rest.config.domain;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;
 import lombok.Data;
+import org.damap.base.domain.ColorTheme;
+import org.damap.base.domain.Image;
 
 /** ConfigDO class. */
 @Data
@@ -26,4 +28,6 @@ public class ConfigDO {
   private boolean livePreviewAvailable;
   private boolean ethicalReportEnabled;
   private String appTitle;
+  private ColorTheme colorTheme;
+  private List<Image> images;
 }

--- a/src/main/java/org/damap/base/rest/theme/service/ColorThemeService.java
+++ b/src/main/java/org/damap/base/rest/theme/service/ColorThemeService.java
@@ -1,0 +1,24 @@
+package org.damap.base.rest.theme.service;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import lombok.extern.jbosslog.JBossLog;
+import org.damap.base.domain.ColorTheme;
+
+@ApplicationScoped
+@JBossLog
+public class ColorThemeService {
+
+  @Transactional
+  public ColorTheme getTheme() {
+    return ColorTheme.findAll().firstResult();
+  }
+
+  @Transactional
+  public ColorTheme uploadTheme(@Valid ColorTheme colorTheme) {
+    ColorTheme.deleteAll();
+    colorTheme.persist();
+    return colorTheme;
+  }
+}

--- a/src/main/java/org/damap/base/rest/theme/service/ImageThemeService.java
+++ b/src/main/java/org/damap/base/rest/theme/service/ImageThemeService.java
@@ -1,0 +1,183 @@
+package org.damap.base.rest.theme.service;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ClientErrorException;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import lombok.extern.jbosslog.JBossLog;
+import org.damap.base.domain.Image;
+import org.hibernate.Hibernate;
+import org.jboss.resteasy.reactive.multipart.FileUpload;
+
+@ApplicationScoped
+@JBossLog
+public class ImageThemeService {
+
+  public enum AllowedImageType {
+    PNG("image/png"),
+    JPEG("image/jpeg"),
+    JPG("image/jpg"),
+    GIF("image/gif"),
+    SVG("image/svg+xml"),
+    WEBP("image/webp");
+
+    private final String mimeType;
+
+    AllowedImageType(String mimeType) {
+      this.mimeType = mimeType;
+    }
+
+    public String getMimeType() {
+      return mimeType;
+    }
+
+    public static boolean isAllowed(String mimeType) {
+      if (mimeType == null) {
+        return false;
+      }
+      for (AllowedImageType type : values()) {
+        if (type.mimeType.equals(mimeType)) {
+          return true;
+        }
+      }
+      return false;
+    }
+  }
+
+  // Maximum file size: 5MB
+  private static final long MAX_FILE_SIZE = 5 * 1024 * 1024;
+
+  @Transactional
+  public Image uploadImage(String imageKey, FileUpload file) {
+    if (imageKey == null || imageKey.isBlank()) {
+      throw new BadRequestException("Image key is required");
+    }
+
+    if (file == null || file.uploadedFile() == null) {
+      throw new BadRequestException("File is required");
+    }
+
+    try {
+      byte[] imageData = Files.readAllBytes(file.uploadedFile());
+
+      if (imageData.length == 0) {
+        throw new BadRequestException("No image data provided");
+      }
+
+      if (imageData.length > MAX_FILE_SIZE) {
+        throw new ClientErrorException(
+            "File size exceeds maximum allowed size of " + (MAX_FILE_SIZE / 1024 / 1024) + "MB",
+            Response.Status.REQUEST_ENTITY_TOO_LARGE);
+      }
+
+      String mimeType = detectMimeType(file);
+
+      if (!isAllowedImageType(mimeType)) {
+        throw new ClientErrorException(
+            "Unsupported image type: " + mimeType + ". Allowed types: " + getAllowedTypesString(),
+            Response.Status.UNSUPPORTED_MEDIA_TYPE);
+      }
+
+      Image existingImage = Image.find("imageKey", imageKey).firstResult();
+
+      Image image;
+      if (existingImage != null) {
+        existingImage.setData(imageData);
+        existingImage.setFilesize((long) imageData.length);
+        existingImage.setMimeType(mimeType);
+        existingImage.persist();
+        log.info("Updated existing image for key: " + imageKey);
+        image = existingImage;
+      } else {
+        image = new Image(imageKey, imageData, (long) imageData.length, mimeType);
+        image.persist();
+        log.info("Created new image for key: " + imageKey);
+      }
+
+      return image;
+
+    } catch (IOException e) {
+      throw new InternalServerErrorException("Failed to upload image", e);
+    }
+  }
+
+  @Transactional
+  public List<Image> getImages() {
+    List<Image> images = Image.findAll().list();
+    images.forEach(img -> Hibernate.initialize(img.getData()));
+    return images;
+  }
+
+  @Transactional
+  public void deleteImage(String imageKey) {
+    if (imageKey == null || imageKey.isBlank()) {
+      throw new BadRequestException("Image key is required");
+    }
+
+    if (Image.delete("imageKey", imageKey) == 0) {
+      throw new NotFoundException("Image not found for key: " + imageKey);
+    }
+  }
+
+  private String detectMimeType(FileUpload file) {
+    // MIME from header
+    String mimeType = file.contentType();
+    if (mimeType != null && !mimeType.isBlank()) {
+      return mimeType;
+    }
+
+    // MIME from filename
+    String filename = file.fileName();
+    if (filename != null && !filename.isBlank()) {
+      mimeType = detectMimeTypeFromExtension(filename);
+      if (mimeType != null) {
+        return mimeType;
+      }
+    }
+
+    // MIME from content
+    try {
+      mimeType = Files.probeContentType(file.uploadedFile());
+      if (mimeType != null && !mimeType.isBlank()) {
+        return mimeType;
+      }
+    } catch (IOException e) {
+      // ignore and return the fallback
+    }
+
+    // fallback
+    return MediaType.APPLICATION_OCTET_STREAM;
+  }
+
+  private String detectMimeTypeFromExtension(String filename) {
+    String extension = filename.substring(filename.lastIndexOf('.') + 1).toLowerCase();
+    return switch (extension) {
+      case "png" -> "image/png";
+      case "jpg", "jpeg" -> "image/jpeg";
+      case "gif" -> "image/gif";
+      case "svg" -> "image/svg+xml";
+      case "webp" -> "image/webp";
+      case "ico" -> "image/x-icon";
+      default -> null;
+    };
+  }
+
+  private String getAllowedTypesString() {
+    StringBuilder sb = new StringBuilder();
+    for (AllowedImageType type : AllowedImageType.values()) {
+      sb.append(type.getMimeType()).append(", ");
+    }
+    return sb.toString().substring(0, sb.length() - 2);
+  }
+
+  private boolean isAllowedImageType(String mimeType) {
+    return AllowedImageType.isAllowed(mimeType);
+  }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -23,7 +23,7 @@ damap:
     # Role name used to identify DAMAP super admins
     # If DAMAP is locally deployed ADMIN_ROLE constant in the DefaultProfile test profile needs to be
     # the same as here, otherwise the tests fail
-    admin-role-name: DAMAP ADMIN
+    admin-role-name: Damap Admin
   repositories:
     # Zenodo, Open Science Framework, DRYAD, Mendeley Data
     # can also be [] for no repositories recommendation

--- a/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.7.0_1.yaml
+++ b/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.7.0_1.yaml
@@ -1,0 +1,100 @@
+databaseChangeLog:
+  - changeSet:
+      id: 25
+      author: Vlad Dancea
+      comment: Create color-theme, image-theme and recommended-repository tables
+      changes:
+        - createSequence:
+            sequenceName: color_theme_seq
+            startValue: 1
+            incrementBy: 50
+
+        - createTable:
+            tableName: color_theme
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  constraints:
+                    primaryKey: true
+              - column:
+                  name: exact_colors
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: colors
+                  type: CLOB
+                  constraints:
+                    nullable: false
+
+        - createSequence:
+            sequenceName: image_seq
+            startValue: 1
+            incrementBy: 50
+
+        - createTable:
+            tableName: image
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  constraints:
+                    primaryKey: true
+              - column:
+                  name: image_key
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+                    unique: true
+              - column:
+                  name: data
+                  type: BLOB
+                  constraints:
+                    nullable: false
+              - column:
+                  name: filesize
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: mime_type
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+
+
+        - createSequence:
+            sequenceName: recommended_repository_seq
+            startValue: 1
+            incrementBy: 50
+
+        - createTable:
+            tableName: recommended_repository
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  constraints:
+                    primaryKey: true
+              - column:
+                  name: repository_id
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+                    unique: true
+
+      rollback:
+        - dropTable:
+            tableName: recommended_repository
+        - dropSequence:
+            sequenceName: recommended_repository_seq
+        - dropTable:
+            tableName: image
+        - dropSequence:
+            sequenceName: image_seq
+        - dropTable:
+            tableName: color_theme
+        - dropSequence:
+            sequenceName: color_theme_seq

--- a/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.x.yaml
+++ b/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.x.yaml
@@ -29,3 +29,6 @@ databaseChangeLog:
       file: org/damap/base/db/changeLog-4.x/changeLog-4.5.2_2.yaml
   - include:
       file: org/damap/base/db/changeLog-4.x/changeLog-4.5.2_3.yaml
+  - include:
+      file: org/damap/base/db/changeLog-4.x/changeLog-4.7.0_1.yaml
+

--- a/src/test/java/org/damap/base/TestProfiles.java
+++ b/src/test/java/org/damap/base/TestProfiles.java
@@ -24,7 +24,7 @@ public class TestProfiles {
 
     // admin role name is configured in application.yaml under damap.auth.admin-role-name
     // but @TestSecurity cannot read from the application.yaml, so it needs to be hardcoded here
-    public static final String ADMIN_ROLE = "DAMAP ADMIN";
+    public static final String ADMIN_ROLE = "Damap Admin";
 
     /** Makes sure that only the Mock services are used and not real systems like PURE */
     @Override


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
Allows the admin to save configurations for Colors, Images, and Recommended Repositories in the database.

#### What does this PR do?

_Color Theme_
Allows for colors to be saved in the database, from which the frontend generates the color scheme.

_Images_
Allows for images to be saved in the database, which the frontend loads instead of the default images located in the assets folder.

_Recommended Repositories_
Replaces hardcoded repositories from application.yaml with a database table.

#### Dependencies
Frontend: https://github.com/damap-org/damap-frontend/pull/488

@DanceaVlad  - Initial implementation of theme service and theme image resources, final cleanup of all three changes
@lpandath  - continued dev of image service and repository management system

closes GH-407
