### PR TITLE
Switch Keycloak to official image & shorten CI workflow name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Continuous Integration Checks
+name: CI Checks
 
 on:
   push:

--- a/docker/docker-compose.common.yaml
+++ b/docker/docker-compose.common.yaml
@@ -26,25 +26,29 @@ services:
       - damap-fe
       - damap-be
   keycloak:
-    image: bitnami/keycloak:23
+    image: quay.io/keycloak/keycloak:26.3
     pull_policy: always
     restart: unless-stopped
+    command:
+      - start
+      - --http-enabled=true
+      - --import-realm
     environment:
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
-
-      KEYCLOAK_DATABASE_HOST: keycloak-db
-      KEYCLOAK_DATABASE_NAME: keycloak
-      KEYCLOAK_DATABASE_USER: keycloak
-      KEYCLOAK_DATABASE_PORT: 5432
-      KEYCLOAK_DATABASE_PASSWORD: keycloak
-
-      # Import realms found in /opt/bitnami/keycloak/data/import
-      KEYCLOAK_EXTRA_ARGS: "--import-realm"
+      KC_BOOTSTRAP_ADMIN_USERNAME: ${KC_BOOTSTRAP_ADMIN_USERNAME:-admin}
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KC_BOOTSTRAP_ADMIN_PASSWORD:-admin}
+      KC_DB: postgres
+      KC_DB_URL_HOST: keycloak-db
+      KC_DB_URL_PORT: 5432
+      KC_DB_URL_DATABASE: keycloak
+      KC_DB_USERNAME: keycloak
+      KC_DB_PASSWORD: keycloak
+      KC_HOSTNAME: ${KC_HOSTNAME:-http://localhost:8087}
+      # Only needed if hostname is localhost
+      KC_HOSTNAME_BACKCHANNEL_DYNAMIC: ${KC_HOSTNAME_BACKCHANNEL_DYNAMIC:-true}
     ports:
       - "8087:8080"
     volumes:
-      - ./sample-damap-realm-export.json:/opt/bitnami/keycloak/data/import/sample-damap-realm-export.json
+      - ./sample-damap-realm-export.json:/opt/keycloak/data/import/damap-realm-import.json
     depends_on:
       - keycloak-db
 


### PR DESCRIPTION
## Description
This PR contains two related maintenance changes:

1. CI workflow name
Renames the GitHub Actions workflow from Continuous Integration Checks → CI Checks. Makes job names shorter and easier to read in the UI.

2. Keycloak image change: Bitnami no longer maintains a Keycloak image. See https://github.com/bitnami/charts/issues/35164#issuecomment-3294431154

### Checks
<!-- Adjust list as necessary -->
- [X] Tested with Oracle/PostgreSQL
- [X] Full Docker compose setup
- [x] UI manual checks