### PR TITLE
Preview: add license to dataset table

### DIFF
--- a/src/main/java/org/damap/base/conversion/AbstractTemplateExportFunctions.java
+++ b/src/main/java/org/damap/base/conversion/AbstractTemplateExportFunctions.java
@@ -504,10 +504,16 @@ public abstract class AbstractTemplateExportFunctions {
     hyperlink.setStyle("Hyperlink");
     hyperlink.setFontSize(run.getFontSize());
     hyperlink.setFontFamily(run.getFontFamily());
-    hyperlink.setText(run.getText(0));
-
-    paragraph.removeRun(runPos);
-
+    // For multiple reused datasets, the run at index runPos is already an XWPFHyperlink run
+    // (bug, should be fixed in the future) causing removeRun from the XPWFParagraph class
+    // to throw an exception. For this reason, we don't need to set the text nor delete the run if
+    // we are in this situation.
+    if (!(paragraph.getRuns().get(runPos) instanceof XWPFHyperlinkRun)) {
+      hyperlink.setText(run.getText(0));
+    }
+    if (!(paragraph.getRuns().get(runPos) instanceof XWPFHyperlinkRun)) {
+      paragraph.removeRun(runPos);
+    }
     for (int i = 0; i < runsAfterHyperlinkRun; i++) {
       XWPFRun runToRemove = paragraph.getRuns().get(runPos);
 

--- a/src/main/java/org/damap/base/conversion/AbstractTemplateExportScienceEuropeComponents.java
+++ b/src/main/java/org/damap/base/conversion/AbstractTemplateExportScienceEuropeComponents.java
@@ -1227,6 +1227,14 @@ public abstract class AbstractTemplateExportScienceEuropeComponents
         docVar.add(Optional.ofNullable(dataset.getDescription()).orElse(""));
 
         insertTableCells(xwpfTable, newRow, docVar);
+        if (dataset.getLicense() != null) {
+          ELicense license = reusedDatasets.get(i).getLicense();
+          XWPFParagraph paragraph = newRow.getCell(3).getParagraphs().get(0);
+          if (license != ELicense.NOLICENSE && license != ELicense.CUSTOM) {
+            turnRunIntoHyperlinkRun(paragraph.getRuns().get(0), license.getUrl());
+          }
+          commitTableRows(xwpfTable);
+        }
       }
       xwpfTable.removeRow(xwpfTable.getRows().size() - 1);
       xwpfTable.removeRow(1);

--- a/src/main/java/org/damap/base/conversion/AbstractTemplateExportScienceEuropeComponents.java
+++ b/src/main/java/org/damap/base/conversion/AbstractTemplateExportScienceEuropeComponents.java
@@ -1208,9 +1208,8 @@ public abstract class AbstractTemplateExportScienceEuropeComponents
         }
 
         if (dataset.getLicense() != null) {
-          // TODO second String license option for reused datasets.
           // TODO use addHyperlinkRun to create hyperlinks - see publication table
-          docVar.add("");
+          docVar.add(dataset.getLicense().getAcronym());
         } else {
           docVar.add("");
         }
@@ -1224,6 +1223,8 @@ public abstract class AbstractTemplateExportScienceEuropeComponents
         } else {
           docVar.add("no");
         }
+
+        docVar.add(Optional.ofNullable(dataset.getDescription()).orElse(""));
 
         insertTableCells(xwpfTable, newRow, docVar);
       }


### PR DESCRIPTION
## Description

License for reused datasets was not exported into PDF previously, this PR fixes that problem. Due to a  bug in the export, a workaround was used - this workaround will be obsolote with the new templating engine upgrade, so its fine to leave it in for now.