### PR TITLE
Deployment: Fix Maven and Github Packages deployment using GPG signing

### DIFF
--- a/.github/workflows/WORKFLOWS.md
+++ b/.github/workflows/WORKFLOWS.md
@@ -46,7 +46,11 @@ but this time with a configuration for Maven Central. As before, the artifacts a
 signed by a GPG agent by the maven-gpg-plugin, and then published on Maven Central using
 the Central credentials retrieved from the Github secrets.
 
-For context, our partner institutions currently use the Maven releases for deployment.
+Once the JAR files are released to Maven Central, they can be consumed as follows:
+- Import the JAR files as a dependency in a new `<dependency>` block in a separate `pom.xml`.
+Specify the `<groupId>`, `<artifactId>` and `<version>`.
+- Declare the dependency in Gradle in the `dependencies` block. The `implementation` configuration 
+can be used for this.
 
 
 

--- a/.github/workflows/WORKFLOWS.md
+++ b/.github/workflows/WORKFLOWS.md
@@ -1,0 +1,53 @@
+# Workflows
+
+This folder contains 3 Github Actions workflows. All jobs are performed in parallel on a
+separate Github runner and each job contains steps which are done sequentially.
+
+- `ci.yml` spins up the containers and runs CI checks such as a DB health check and Maven 
+tests.
+
+- `release.yml` automates the deployment of the backend to Github Packages while another job
+builds and then publishes the Docker image to the Docker registry. 
+
+- `release-maven.yml` automates the deployment of the backend to the Maven Central repository.
+
+## `ci.yml`
+This workflow is automatically triggered upon each Pull Request, each push to `next` and can
+also be triggered manually [here](https://github.com/damap-org/damap-backend/actions/workflows/ci.yml).
+
+The `matrix` strategy is used which allows us to run each job more than once with different
+configurations, for instance for running the CI checks on a Postgres DB as well as on an 
+Oracle one.
+
+Two jobs are defined: `test-docker` builds the Docker image, starts the DAMAP containers and
+sees if the application is responding with an `HTTP ok`. The second job, `test-maven`, runs a
+DB healthcheck using Oracle, h2 and Postgres, then runs the DAMAP Maven tests.
+
+## `release.yml` 
+`release.yml` is automatically triggered when a branch is pushed with a version tag, when 
+someone pushes to `next` or `master`, or manually [here](
+https://github.com/damap-org/damap-backend/actions/workflows/release.yml
+).
+
+The job github-deploy `github-deploy` first sets up JDK17 and automatically configures the
+GPG secret key and passphrase retrieved from Github secrets and then signs and publishes the
+`jar` artefacts to Github Packages. The other job, `container-build-publish` is responsible for 
+building and pushing the Docker image, using the Github token defined as a Github secret.
+
+
+## `release-meaven.yml`
+This workflow is triggered when changes are pushed with a `version` tag or manually [here](
+https://github.com/damap-org/damap-backend/actions/workflows/release-maven.yml
+). In the case of a manual trigger, an input is required from the user to indicate
+the version that is being published.
+
+The single job `maven-deploy` is responsible for setting up JDK17 similarly to `release.yml` 
+but this time with a configuration for Maven Central. As before, the artifacts are automatically
+signed by a GPG agent by the maven-gpg-plugin, and then published on Maven Central using
+the Central credentials retrieved from the Github secrets.
+
+For context, our partner institutions currently use the Maven releases for deployment.
+
+
+
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   # This job builds the Docker images and runs a health check to ensure the
   # backend service is up and running. It uses 2 databases: Oracle and Postgres.

--- a/.github/workflows/release-maven.yml
+++ b/.github/workflows/release-maven.yml
@@ -1,38 +1,57 @@
 name: release maven central repository
-
 on:
   push:
     tags:
       - v*
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version to test (e.g., 0.0.1-test)'
+        required: true
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   maven-deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        # Get the version either from the Github tag if CI release, or from user input if workflow manually
+        # triggered. In both cases, replace the "0.0.0-SNAPSHOT" placeholder in pom.xml by the version.
       - name: Change Maven version
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
         run: |
-          VERSION=$(echo -n '${{ github.ref_name }}' | sed -e 's/v//')
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            VERSION=$(echo -n '${{ github.ref_name }}' | sed -e 's/v//')
+            echo "Using version from tag: $VERSION"
+          else
+            # This is a manual test run, use the version from the input
+            VERSION="${{ github.event.inputs.version }}"
+            echo "Using version from manual input: $VERSION"
+          fi
           sed -i "s/0.0.0-SNAPSHOT/${VERSION}/" pom.xml
+
+      # Sets up JDK17 and the GPG agent with our GPG private key and the passphrase to access its content.
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v4.2.1
         with:
-          distribution: "adopt"
+          distribution: "temurin"
           java-version: 17.0
           server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: GPG_PASSPHRASE
+          gpg-passphrase: ${{ secrets.GPG_KEY_PASS }}
+
+      # This step publishes the jar files to Maven Central and the maven-gpg-plugin automatically signs the jar files
+      # using our GPG key passed above.
+      # Maven Central needs the step above to define server-id this way. But the side effect is that a settings.xml
+      # file is created. Without specifying MAVEN_GPG_PASSPHRASE again below, maven would see that file, ignore the gpg
+      # agent and looks for a non-existent settings-security.xml to retrieve the gpg pass phrase.
       - name: Publish package
         run: mvn --batch-mode -P deploy-mvn-repository deploy # same profile id as specified in pom.xml for maven deployment
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_KEY_PASS}}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_KEY_PASS }}

--- a/.github/workflows/release-maven.yml
+++ b/.github/workflows/release-maven.yml
@@ -3,11 +3,6 @@ on:
   push:
     tags:
       - v*
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'The version to test (e.g., 0.0.1-test)'
-        required: true
 
 permissions:
   contents: read
@@ -17,19 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        # Get the version either from the Github tag if CI release, or from user input if workflow manually
-        # triggered. In both cases, replace the "0.0.0-SNAPSHOT" placeholder in pom.xml by the version.
+        # Get the version from the Github tag if CI release. Replace the "0.0.0-SNAPSHOT" placeholder in pom.xml with
+        # the version.
       - name: Change Maven version
-        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            VERSION=$(echo -n '${{ github.ref_name }}' | sed -e 's/v//')
-            echo "Using version from tag: $VERSION"
-          else
-            # This is a manual test run, use the version from the input
-            VERSION="${{ github.event.inputs.version }}"
-            echo "Using version from manual input: $VERSION"
-          fi
+          VERSION=$(echo -n '${{ github.ref_name }}' | sed -e 's/v//')
+          echo "Using version from tag: $VERSION"
           sed -i "s/0.0.0-SNAPSHOT/${VERSION}/" pom.xml
 
       # Sets up JDK17 and the GPG agent with our GPG private key and the passphrase to access its content.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,12 @@ jobs:
           VERSION=$(echo -n '${{ github.ref_name }}' | sed -e 's/v//')
           sed -i "s/0.0.0-SNAPSHOT/${VERSION}/" pom.xml
 
-      # Upload the 4 jar files to Github Packages. The maven gpg plugin first automatically signs the files using the
-      # gpg private key.
+      # The maven gpg plugin automatically signs the following 4 files using the gpg private key.
+      # 1. Javadoc: base-<version>-javadoc.jar
+      # 2. Sources: base-<version>-sources.jar
+      # 3. Main jar: base-<version>.jar
+      # 4. Pom: base-<version>.pom
+      # All resulting JAR artefacts, checksums and asc signature files are then uploaded to GitHub Packages
       - name: Publish to GitHub packages
         run: mvn deploy --batch-mode -P deploy-github-repository
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,24 +26,30 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Sets up JDK17 and the GPG agent with our GPG private key and the passphrase to access its content.
       - name: Set up JDK 17
         uses: actions/setup-java@v4.2.1
         with:
-          distribution: "adopt"
+          distribution: 'temurin'
           java-version: 17.0
+          cache: 'maven'
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: GPG_PASSPHRASE
+          gpg-passphrase: ${{ secrets.GPG_KEY_PASS }}
 
+      # Replace the "0.0.0-SNAPSHOT" placeholder in pom.xml by the version we get from the Github context.
       - name: Change Maven version
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           VERSION=$(echo -n '${{ github.ref_name }}' | sed -e 's/v//')
           sed -i "s/0.0.0-SNAPSHOT/${VERSION}/" pom.xml
 
+      # Upload the 4 jar files to Github Packages. The maven gpg plugin first automatically signs the files using the
+      # gpg private key.
       - name: Publish to GitHub packages
-        run: mvn --batch-mode -P deploy-github-repository deploy
+        run: mvn deploy --batch-mode -P deploy-github-repository
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_KEY_PASS }}
 
   container-build-publish:
     runs-on: ubuntu-latest

--- a/pom.xml
+++ b/pom.xml
@@ -508,7 +508,7 @@
             <extensions>true</extensions>
             <configuration>
               <publishingServerId>central</publishingServerId>
-              <autoPublish>false</autoPublish>
+              <autoPublish>true</autoPublish>
               <waitUntil>published</waitUntil>
             </configuration>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -56,14 +56,6 @@
     <spotless.version>2.44.0.BETA1</spotless.version>
   </properties>
 
-  <distributionManagement>
-    <repository>
-      <id>github</id>
-      <name>GitHub</name>
-      <url>https://maven.pkg.github.com/damap-org/damap-backend</url>
-    </repository>
-  </distributionManagement>
-
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -452,10 +444,16 @@
 
     <profile>
       <id>deploy-github-repository</id>
+      <distributionManagement>
+        <repository>
+          <id>github</id>
+          <name>GitHub</name>
+          <url>https://maven.pkg.github.com/damap-org/damap-backend</url>
+        </repository>
+      </distributionManagement>
       <build>
         <plugins>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>3.2.4</version>
             <executions>
@@ -465,6 +463,13 @@
                 <goals>
                   <goal>sign</goal>
                 </goals>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                  <passphraseServerId/>
+                </configuration>
               </execution>
             </executions>
           </plugin>
@@ -477,7 +482,6 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>3.2.4</version>
             <executions>
@@ -487,6 +491,13 @@
                 <goals>
                   <goal>sign</goal>
                 </goals>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                  <passphraseServerId/>
+                </configuration>
               </execution>
             </executions>
           </plugin>
@@ -497,7 +508,7 @@
             <extensions>true</extensions>
             <configuration>
               <publishingServerId>central</publishingServerId>
-              <autoPublish>true</autoPublish>
+              <autoPublish>false</autoPublish>
               <waitUntil>published</waitUntil>
             </configuration>
           </plugin>


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->
Bugfix
#### Context
The DAMAP backend can be deployed in two ways: via an upload on Github Packages (done in `release.yml`), or on Maven Central (done in `release-maven.yml`). Note that the latter option is currently the one being used by partner institutions. A few months ago, automatic deployment broke because of a combination of factors I will explain below and Maven deployment had to be done manually since. In order to prove that the produced artefacts (most importantly the `jar` file that maven produces) are really from us, `damap-org`, we need to sign them using the open source tool GPG.

#### Changes in this PR
<!-- Changes introduced by this PR - what happened before, what happens now -->
 ##### `release-maven.yml`
1)  **Enabled manual workflow trigger**: If the workflow was triggered automatically, the `pom.xml` file gets the version by looking at the tag of the github release. For this reason: Added a text input `version` when manually triggering this workflow. Ultimately, the `jar` file that gets uploaded is the same code no matter what version is set here, but it does affect the naming of the `jar` files etc. 
2)  **Updated Java Distribution**: The `adopt` distribution is deprecated and should be replaced by `temurin` (see https://hub.docker.com/_/adoptopenjdk). Leaving it as it was also led to an error.
3) **Fixed GPG Passphrase Handling**: In the `Set up JDK 17` step, the environment variable `GPG_KEY_PASS` from the githubs secrets should be passed as the GPG passphrase to the GPG agent, not the string `GPG_PASSPHRASE`.
4) **Updated Central Credentials**: Replaced the OSSRH credentials by newly generated Maven Central ones, since OSSRH reached EOL and shut down (see https://central.sonatype.org/pages/ossrh-eol/). As before, these values are imported from the Github secrets.
5) **Least Privilege**: Removed write permission of the GitHub token to GitHub packages since this is not needed in this workflow.

##### `release.yml`
2) same as above
3) same as above + The passphrase should also be specified in the deploy step.

##### `ci.yml`
1) Set the `GITHUB_TOKEN` permissions in the CI pipeline workflow file with the least privilege needed. This is important for security, since otherwise third-party software (for instance S4U) that is compromised could simply access the `GITHUB_TOKEN` from an environment variable in the runner. This would allow them to make changes in our code base without much effort. Leaving out the permissions sections leads to default repository permissions for the token, i.e., read & write permissions.
From the GitHub actions [docs](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token):
_An action can access the `GITHUB_TOKEN` through the `github.token` context even if the workflow does not explicitly pass the `GITHUB_TOKEN` to the action. As a good security practice, you should always make sure that actions only have the minimum access they require by limiting the permissions granted to the `GITHUB_TOKEN.`_

##### `pom.xml`
1) **Wrong profile placement:** Moved the distribution management set up for Github Packages from the global section to the appropriate profile. Otherwise parameters such as the url would lead the maven workflow to try to upload to Github Packages instead of Maven Central, which does not work because of the different credentials.
2) **Pinentry mode -> loopback:** The pinentry mode has been set to loopback so the maven gpg plugin does not ignore the gpg passphrase that is passed, which seems hacky but is the official way to solve this (see https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#publishing-using-apache-maven). 

Note to people working on this in the future: be careful since LLMs tend to spit out a lot of wrong explanations and code on this particular topic.

### How to verify if this works?
**Github Packages**: go to https://github.com/damap-org/damap-backend/actions/workflows/release.yml -> Run workflow -> Select the branch (which may be next if this PR is merged). Careful since only Admins can then delete the test Github package.
**Maven Central**: ❗  SET `<autoPublish>false</autoPublish>` in `pom.xml`  to not mess up with actual deployment first❗ Then go to https://github.com/damap-org/damap-backend/actions/workflows/release-maven.yml -> Run workflow -> input the version for testing.

closes GH-https://github.com/damap-org/damap-backend/issues/435
