### PR TITLE
Config: Add default pure url

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -59,7 +59,7 @@ damap:
   elsevier-pure-project-lead-role-classification: /dk/atira/pure/projectlead
   ## HTTP backend:
   elsevier-pure-backend: http
-  elsevier-pure-endpoint-url: ""
+  elsevier-pure-endpoint-url: "https://your-pure-instance.elsevierpure.com/ws/api"
   elsevier-pure-api-key: "your API key here"
   ## Alternatively, the file-based backend:
   # elsevier-pure-backend: file
@@ -183,8 +183,5 @@ rest:
         url: jdbc:h2:mem:test
     oidc:
       enabled: false
-    rest-client:
-      elsevier-pure:
-        url: "http://localhost:9999/fake-pure-api"
   rest:
     elsevier-pure/mp-rest/url: "http://localhost:9999/fake-pure-api"


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
Bugfix

#### What does this PR do?
Add a default pure url to the application yaml instead of empty "". This prevents the project service from failing when the default project service was chosen. Tests should still run as normal.
