### PR TITLE
Pure: Avoid ClassCastException when project contains external participants

### DIFF
--- a/src/main/java/org/damap/base/integration/pure/PureProjectService.java
+++ b/src/main/java/org/damap/base/integration/pure/PureProjectService.java
@@ -120,6 +120,11 @@ public class PureProjectService implements ProjectServiceProvider {
             .filter(
                 project ->
                     project.participants.stream()
+                        // Filter by internal participants only, since external participants are
+                        // not able to have a DAMAP account now and for the foreseeable future.
+                        .filter(
+                            participant ->
+                                participant instanceof PureAPIInternalParticipantAssociation)
                         .anyMatch(
                             participant ->
                                 ((PureAPIInternalParticipantAssociation) participant)


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->
Bugfix

#### What does this PR do?
<!-- Changes introduced by this PR - what happened before, what happens now -->
Testing the PURE integration with a project file containing external participants, such as `damap-backend/src/test/resources/org/damap/base/integration/pure/projects.json` leads to a `ClassCastException`: 

<img width="1917" height="233" alt="Untitled" src="https://github.com/user-attachments/assets/7f5176a9-3652-4cfa-adfe-af6b128056c7" />

The reason for this is the method to get the recommended projects in the first step, which casts every participant to the class `PureAPIInternalParticipantAssociation`, in particular even external participants. This PR fixes the issue by pre-filtering by internal participants only. Since external participants are not able to have a DAMAP account, we do not need to recommend projects where they are a participant.