### PR TITLE
EduId integration

### DIFF
--- a/src/main/java/org/damap/base/rest/AdminResource.java
+++ b/src/main/java/org/damap/base/rest/AdminResource.java
@@ -28,7 +28,7 @@ public class AdminResource {
 
   @POST
   @Path("/banner")
-  @RolesAllowed("Damap Admin")
+  @RolesAllowed("${damap.auth.admin-role-name}")
   public BannerDO createAppBanner(@Valid BannerDO bannerDO) {
     log.info("POST /admin/banner");
     log.info(bannerDO);
@@ -37,7 +37,7 @@ public class AdminResource {
 
   @PUT
   @Path("/banner")
-  @RolesAllowed("Damap Admin")
+  @RolesAllowed("${damap.auth.admin-role-name}")
   public BannerDO updateAppBanner(@Valid BannerDO bannerDO) {
     log.info("PUT /admin/banner");
     log.info(bannerDO);
@@ -46,7 +46,7 @@ public class AdminResource {
 
   @DELETE
   @Path("/banner")
-  @RolesAllowed("Damap Admin")
+  @RolesAllowed("${damap.auth.admin-role-name}")
   public void deleteAppBanner() {
     log.info("DELETE /admin/banner");
     this.adminService.deleteAppBanner();

--- a/src/main/java/org/damap/base/rest/ConfigResource.java
+++ b/src/main/java/org/damap/base/rest/ConfigResource.java
@@ -18,17 +18,35 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 @PermitAll
 @JBossLog
 public class ConfigResource {
-  @ConfigProperty(name = "damap.auth.frontend.url")
-  String authUrl;
+  @ConfigProperty(name = "damap.auth.server-url")
+  String issuer;
 
-  @ConfigProperty(name = "damap.auth.frontend.client")
-  String authClient;
+  @ConfigProperty(name = "damap.auth.clientID")
+  String clientID;
 
   @ConfigProperty(name = "damap.auth.scope")
-  String authScope;
+  String scope;
 
-  @ConfigProperty(name = "damap.auth.user")
-  String authUser;
+  @ConfigProperty(name = "damap.auth.user-roles-claim-path")
+  String userRolesClaimPath;
+
+  @ConfigProperty(name = "damap.auth.user-id-claim")
+  String userIdClaim;
+
+  @ConfigProperty(name = "damap.auth.name-claim")
+  String nameClaim;
+
+  @ConfigProperty(name = "damap.auth.given-name-claim")
+  String givenNameClaim;
+
+  @ConfigProperty(name = "damap.auth.family-name-claim")
+  String familyNameClaim;
+
+  @ConfigProperty(name = "damap.auth.email-claim")
+  String emailClaim;
+
+  @ConfigProperty(name = "damap.auth.admin-role-name")
+  String adminRoleName;
 
   @ConfigProperty(name = "damap.env")
   String env;
@@ -56,10 +74,17 @@ public class ConfigResource {
   @GET
   public ConfigDO config() {
     ConfigDO configDO = new ConfigDO();
-    configDO.setAuthUrl(authUrl);
-    configDO.setAuthClient(authClient);
-    configDO.setAuthScope(authScope);
-    configDO.setAuthUser(authUser);
+    configDO.setIssuer(issuer);
+    configDO.setClientID(clientID);
+    configDO.setScope(scope);
+    configDO.setUserRolesClaimPath(userRolesClaimPath);
+    configDO.setUserIdClaim(userIdClaim);
+    configDO.setNameClaim(nameClaim);
+    configDO.setGivenNameClaim(givenNameClaim);
+    configDO.setFamilyNameClaim(familyNameClaim);
+    configDO.setEmailClaim(emailClaim);
+    configDO.setAdminRoleName(adminRoleName);
+    configDO.setResponseType("code"); // hardcoded since DAMAP only supports this flow
     configDO.setEnv(env);
     configDO.setAppTitle(appTitle);
     configDO.setPersonSearchServiceConfigs(personServiceConfigurations.getConfigs());

--- a/src/main/java/org/damap/base/rest/DataManagementPlanResource.java
+++ b/src/main/java/org/damap/base/rest/DataManagementPlanResource.java
@@ -43,7 +43,7 @@ public class DataManagementPlanResource {
    */
   @GET
   @Path("/all")
-  @RolesAllowed("Damap Admin")
+  @RolesAllowed("${damap.auth.admin-role-name}")
   public List<DmpListItemDO> getAll() {
     log.info("Return all Dmps");
     return dmpService.getAll();
@@ -51,7 +51,7 @@ public class DataManagementPlanResource {
 
   /*@GET
   @Path("/person/{personId}")
-  @RolesAllowed("Damap Admin")
+  @RolesAllowed("${damap.auth.admin-role-name}")
   public List<DmpListItemDO> getDmpListByPerson(@RestPath String personId) {
       log.info("Return dmp for person id: " + personId);
       return dmpService.getDmpListByPersonId(personId);

--- a/src/main/java/org/damap/base/rest/InternalStorageResource.java
+++ b/src/main/java/org/damap/base/rest/InternalStorageResource.java
@@ -40,7 +40,7 @@ public class InternalStorageResource
   @POST
   @Path("")
   @Consumes(MediaType.APPLICATION_JSON)
-  @RolesAllowed("Damap Admin")
+  @RolesAllowed("${damap.auth.admin-role-name}")
   public InternalStorageDO create(@Valid InternalStorageDO data) {
     log.debug("Create internal storage option");
     log.debug(data);
@@ -95,7 +95,7 @@ public class InternalStorageResource
   @PUT
   @Path("/{id}")
   @Consumes(MediaType.APPLICATION_JSON)
-  @RolesAllowed("Damap Admin")
+  @RolesAllowed("${damap.auth.admin-role-name}")
   public InternalStorageDO update(@PathParam("id") String id, @Valid InternalStorageDO data) {
     log.debug("Update internal storage option with id " + id);
     log.debug(data);
@@ -110,7 +110,7 @@ public class InternalStorageResource
    */
   @Override
   @DELETE
-  @RolesAllowed("Damap Admin")
+  @RolesAllowed("${damap.auth.admin-role-name}")
   @Path("/{id}")
   public void delete(@PathParam("id") String id) {
     log.debug("Delete internal storage option with id " + id);

--- a/src/main/java/org/damap/base/rest/InternalStorageTranslationResource.java
+++ b/src/main/java/org/damap/base/rest/InternalStorageTranslationResource.java
@@ -29,7 +29,7 @@ public class InternalStorageTranslationResource
   private static final String MESSAGE_START = "{\"message\":\"";
 
   @Override
-  @RolesAllowed("Damap Admin")
+  @RolesAllowed("${damap.auth.admin-role-name}")
   public InternalStorageTranslationDO create(@Valid InternalStorageTranslationDO data) {
     log.debug("Create internal storage translation");
     log.debug(data);
@@ -46,7 +46,7 @@ public class InternalStorageTranslationResource
   }
 
   @Override
-  @RolesAllowed("Damap Admin")
+  @RolesAllowed("${damap.auth.admin-role-name}")
   public void delete(String id) {
     log.info("Delete internal storage translation with id " + id);
     try {
@@ -77,7 +77,7 @@ public class InternalStorageTranslationResource
   }
 
   @Override
-  @RolesAllowed("Damap Admin")
+  @RolesAllowed("${damap.auth.admin-role-name}")
   public InternalStorageTranslationDO update(String id, @Valid InternalStorageTranslationDO data) {
     log.info("Update internal storage translation with id " + id);
     log.info(data);

--- a/src/main/java/org/damap/base/rest/MaDmpResource.java
+++ b/src/main/java/org/damap/base/rest/MaDmpResource.java
@@ -15,7 +15,6 @@ import org.damap.base.rest.madmp.dto.Dmp;
 import org.damap.base.rest.madmp.service.MaDmpService;
 import org.damap.base.security.SecurityService;
 import org.damap.base.validation.AccessValidator;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 /** MaDmpResource class. */
 @Path("/api/madmp")
@@ -32,9 +31,6 @@ public class MaDmpResource {
   @Inject MaDmpService maDmpService;
 
   @Inject DmpService dmpService;
-
-  @ConfigProperty(name = "damap.auth.user")
-  String authUser;
 
   /**
    * getById.

--- a/src/main/java/org/damap/base/rest/config/domain/ConfigDO.java
+++ b/src/main/java/org/damap/base/rest/config/domain/ConfigDO.java
@@ -9,22 +9,21 @@ import lombok.Data;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ConfigDO {
 
-  private String authUrl;
-  private String authClient;
-  private String authScope;
-  private String authUser;
+  private String issuer;
+  private String clientID;
+  private String responseType;
+  private String scope;
+  private String userRolesClaimPath;
+  private String userIdClaim;
+  private String nameClaim;
+  private String givenNameClaim;
+  private String familyNameClaim;
+  private String emailClaim;
+  private String adminRoleName;
   private String env;
   private List<ServiceConfig> personSearchServiceConfigs;
   private boolean fitsServiceAvailable;
   private boolean livePreviewAvailable;
   private boolean ethicalReportEnabled;
   private String appTitle;
-
-  public void setAppTitle(String appTitle) {
-    this.appTitle = appTitle;
-  }
-
-  public String getAppTitle() {
-    return appTitle;
-  }
 }

--- a/src/main/java/org/damap/base/security/SecurityService.java
+++ b/src/main/java/org/damap/base/security/SecurityService.java
@@ -9,8 +9,12 @@ import io.smallrye.jwt.auth.principal.JWTParser;
 import io.smallrye.jwt.auth.principal.ParseException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonString;
 import jakarta.ws.rs.core.HttpHeaders;
 import java.security.Principal;
+import java.util.List;
+import java.util.Optional;
 import lombok.extern.jbosslog.JBossLog;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.jwt.JsonWebToken;
@@ -24,8 +28,17 @@ import org.eclipse.microprofile.jwt.JsonWebToken;
 public class SecurityService {
   @Inject SecurityIdentity securityIdentity;
 
-  @ConfigProperty(name = "damap.auth.user")
-  String authUser;
+  @ConfigProperty(name = "damap.auth.user-id-claim")
+  String userIdClaim;
+
+  @ConfigProperty(name = "damap.auth.admin-role-name")
+  String adminRoleName;
+
+  @ConfigProperty(name = "damap.auth.affiliations-claim")
+  String affiliationsClaim;
+
+  @ConfigProperty(name = "tenants", defaultValue = "")
+  Optional<List<String>> tenants;
 
   @ConfigProperty(name = "invenio.shared-secret")
   String sharedSecret;
@@ -41,7 +54,7 @@ public class SecurityService {
     final Principal principal = securityIdentity.getPrincipal();
     if (!(principal instanceof OidcJwtCallerPrincipal)) return null;
 
-    return ((OidcJwtCallerPrincipal) principal).getClaims().getClaimValue(authUser).toString();
+    return ((OidcJwtCallerPrincipal) principal).getClaims().getClaimValue(userIdClaim).toString();
   }
 
   /**
@@ -52,16 +65,14 @@ public class SecurityService {
   public String getUserName() {
     final Principal principal = securityIdentity.getPrincipal();
     if (!(principal instanceof OidcJwtCallerPrincipal)) return null;
-    return ((OidcJwtCallerPrincipal) principal).getName();
+    return principal.getName();
   }
 
   public String getDisplayName() {
     final Principal principal = securityIdentity.getPrincipal();
-    if (!(principal instanceof OidcJwtCallerPrincipal)) {
+    if (!(principal instanceof OidcJwtCallerPrincipal oidcPrincipal)) {
       return null;
     }
-
-    OidcJwtCallerPrincipal oidcPrincipal = (OidcJwtCallerPrincipal) principal;
 
     String name = getClaimValueAsString(oidcPrincipal, "name");
     if (name != null) {
@@ -88,7 +99,47 @@ public class SecurityService {
    * @return a boolean
    */
   public boolean isAdmin() {
-    return securityIdentity.hasRole("Damap Admin");
+    return securityIdentity.hasRole(adminRoleName);
+  }
+
+  public String getAffiliation() {
+    final Principal principal = securityIdentity.getPrincipal();
+    if (!(principal instanceof OidcJwtCallerPrincipal oidcPrincipal)) {
+      return null;
+    }
+
+    // affiliations come from the eduPersonScopedAffiliation attribute - in EduID they are
+    // structured like role@institution
+    // EduGain does not have this convention - currently we just throw an error if the affiliation
+    // doesnt follow the EduID style
+    // for more information see:
+    // https://wiki.univie.ac.at/spaces/federation/pages/47025278/eduPersonScopedAffiliation
+    List<String> affiliations =
+        ((JsonArray) oidcPrincipal.getClaims().getClaimValue(affiliationsClaim))
+            .stream()
+                .map(JsonString.class::cast)
+                .map(JsonString::getString)
+                .map(
+                    aff -> {
+                      if (!aff.contains("@")) {
+                        throw new UnauthorizedException(
+                            "Affiliation is expected to include an @: " + aff);
+                      }
+                      return aff.split("@")[1];
+                    })
+                .distinct()
+                .toList();
+
+    List<String> tenantList = tenants.orElse(List.of());
+
+    // check if affiliations are actual tenants and if exactly one unique affiliation  is present
+    // currently DAMAP cannot handle multiple affiliations
+    List<String> validAffiliations = affiliations.stream().filter(tenantList::contains).toList();
+    if (validAffiliations.size() == 1) {
+      return validAffiliations.get(0);
+    } else {
+      throw new UnauthorizedException("Exactly one affiliation to a registered tenant is expected");
+    }
   }
 
   /**

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,24 +1,37 @@
 # custom config settings
 # replace these in the config of your custom project or by overriding these variables
 damap:
-  title: ${DAMAP_TITLE:DAMAP Tool}
+  title: DAMAP Tool
   env: DEV # override in your custom project with PROD for production deployment
   origins: http://localhost:8085 # https://your.frontend.com,https://*.yourdomain.com
   auth:
-    backend:
-      # Configures the OIDC realm the DAMAP backend should query to verify authentication:
-      url: http://keycloak:8080/realms/damap      # Client ID as configured in the OIDC Server:
-      client: 'damap-be'
-    frontend:
-      # Configures the OIDC URL the frontend should send users to in order to log in. This is typically the same
-      # as the backend URL, but may differ if the backend can access the OIDC server over a non-public network.
-      url: http://localhost:8087/realms/damap
-      # Client ID as configured in the OIDC Server:
-      client: 'damap'
+    # Configures the OIDC realm the DAMAP backend should query to verify authentication:
+    server-url: http://localhost:8087/realms/damap
+    # Configures the OIDC URL the frontend should send users to in order to log in. This is typically the same
+    # as the backend URL, but may differ if the backend can access the OIDC server over a non-public network.
+    issuer: http://localhost:8087/realms/damap
+    # Client ID as configured in the OIDC Server:
+    clientID: damap
     # Scopes to request during login:
-    scope: 'openid profile email offline_access microprofile-jwt roles personID' # your-backend-authentication-scope, including your variable for your user IDs
+    scope: openid profile affiliation
+    # The OIDC claim path that will hold your DAMAP roles in the access token
+    user-roles-claim-path: roles
     # The OIDC claim to use as a user ID:
-    user: 'personID'
+    user-id-claim: sub
+    # The OIDC claim that holds the users full name
+    name-claim: name
+    # The OIDC claim that holds the users given name
+    given-name-claim: given_name
+    # The OIDC claim that holds the users family name
+    family-name-claim: family_name
+    # The OIDC claim that holds the users email
+    email-claim: email
+    # The OIDC claim that holds the users affiliations
+    affiliations-claim: affiliation
+    # Role name used to identify DAMAP super admins
+    # If its value is not damap-super-admin, ADMIN_ROLE constant in the
+    # DefaultProfile test profile needs to be changed accordingly
+    admin-role-name: damap-super-admin
   datasource:
     url: ${DAMAP_DATASOURCE_URL:jdbc:postgresql://damap-db:5432/damap}
     db-kind: ${DAMAP_DATASOURCE_DB_KIND:postgresql}
@@ -95,10 +108,12 @@ quarkus:
       max-body-size: 10M
 
   oidc:
-    auth-server-url: ${damap.auth.backend.url}
-    client-id: ${damap.auth.backend.client}
+    auth-server-url: ${damap.auth.server-url}
+    client-id: ${damap.auth.clientID}
     token:
-      issuer: ${damap.auth.frontend.url}
+      issuer: ${damap.auth.issuer}
+    roles:
+      role-claim-path: ${damap.auth.user-roles-claim-path}
 
   datasource:
     jdbc:
@@ -130,7 +145,7 @@ quarkus:
 
   swagger-ui:
     always-include: true # set to false if swagger-ui should only be available in dev mode
-    oauth-client-id: ${damap.auth.frontend.client}
+    oauth-client-id: ${damap.auth.clientID}
 
   rest-client:
     elsevier-pure:
@@ -154,8 +169,13 @@ rest:
     title: "DAMAP (Development)"
     origins: http://localhost:4200
     auth:
-      backend:
-        url: http://localhost:8087/realms/damap # https://your.authentication.server
+      server-url: http://localhost:8087/realms/damap
+      issuer: http://localhost:8087/realms/damap
+      clientID: damap
+      scope: 'openid profile email offline_access microprofile-jwt roles personID'
+      user-id-claim: personID
+      user-roles-claim-path: realm_access/roles
+      admin-role-name: Damap Admin
     datasource:
       url: jdbc:postgresql://localhost:8088/damap
       db-kind: postgresql

--- a/src/test/java/org/damap/base/TestProfiles.java
+++ b/src/test/java/org/damap/base/TestProfiles.java
@@ -22,6 +22,10 @@ public class TestProfiles {
 
   public static class DefaultProfile implements QuarkusTestProfile {
 
+    // admin role name is configured in application.yaml under damap.auth.admin-role-name
+    // but @TestSecurity cannot read from the application.yaml, so it needs to be hardcoded here
+    public static final String ADMIN_ROLE = "damap-super-admin";
+
     /** Makes sure that only the Mock services are used and not real systems like PURE */
     @Override
     public Map<String, String> getConfigOverrides() {

--- a/src/test/java/org/damap/base/rest/AccessResourceTest.java
+++ b/src/test/java/org/damap/base/rest/AccessResourceTest.java
@@ -1,6 +1,7 @@
 package org.damap.base.rest;
 
 import static io.restassured.RestAssured.given;
+import static org.damap.base.TestProfiles.DefaultProfile.ADMIN_ROLE;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 import io.quarkus.test.common.http.TestHTTPEndpoint;
@@ -36,7 +37,7 @@ class AccessResourceTest extends TestSetup {
   }
 
   @Test
-  @TestSecurity(user = "adminJwt", roles = "Damap Admin")
+  @TestSecurity(user = "adminJwt", roles = ADMIN_ROLE)
   void testGetAccessListAdmin_Valid() {
     Mockito.when(securityService.isAdmin()).thenReturn(true);
 
@@ -69,7 +70,7 @@ class AccessResourceTest extends TestSetup {
   }
 
   @Test
-  @TestSecurity(user = "adminJwt", roles = "Damap Admin")
+  @TestSecurity(user = "adminJwt", roles = ADMIN_ROLE)
   void testCreateAccessAdmin_Valid() {
     Mockito.when(securityService.isAdmin()).thenReturn(true);
     AccessDO accessDO = this.createAccessDO();
@@ -122,7 +123,7 @@ class AccessResourceTest extends TestSetup {
   }
 
   @Test
-  @TestSecurity(user = "adminJwt", roles = "Damap Admin")
+  @TestSecurity(user = "adminJwt", roles = ADMIN_ROLE)
   void testDeleteAccessAdmin_Valid() {
     Mockito.when(securityService.isAdmin()).thenReturn(true);
     AccessDO accessDO = this.accessService.create(this.createAccessDO());

--- a/src/test/java/org/damap/base/rest/ConfigResourceTest.java
+++ b/src/test/java/org/damap/base/rest/ConfigResourceTest.java
@@ -15,11 +15,11 @@ import org.junit.jupiter.api.Test;
 @TestProfile(TestProfiles.DefaultProfile.class)
 class ConfigResourceTest {
 
-  @ConfigProperty(name = "damap.auth.frontend.url")
-  String authUrl;
+  @ConfigProperty(name = "damap.auth.server-url")
+  String serverUrl;
 
   @Test
   void testGetConfigEndpoint() {
-    given().when().get().then().statusCode(200).body("authUrl", is(authUrl));
+    given().when().get().then().statusCode(200).body("issuer", is(serverUrl));
   }
 }

--- a/src/test/java/org/damap/base/rest/DataManagementPlanResourceTest.java
+++ b/src/test/java/org/damap/base/rest/DataManagementPlanResourceTest.java
@@ -1,6 +1,7 @@
 package org.damap.base.rest;
 
 import static io.restassured.RestAssured.given;
+import static org.damap.base.TestProfiles.DefaultProfile.ADMIN_ROLE;
 import static org.hamcrest.Matchers.is;
 
 import io.quarkus.test.common.http.TestHTTPEndpoint;
@@ -41,7 +42,7 @@ class DataManagementPlanResourceTest extends TestSetup {
   }
 
   @Test
-  @TestSecurity(user = "adminJwt", roles = "Damap Admin")
+  @TestSecurity(user = "adminJwt", roles = ADMIN_ROLE)
   void testGetAllPlansEndpoint_ValidRole() {
     given().when().get("/all").then().statusCode(200);
   }

--- a/src/test/java/org/damap/base/rest/InternalStorageResourceTest.java
+++ b/src/test/java/org/damap/base/rest/InternalStorageResourceTest.java
@@ -1,6 +1,7 @@
 package org.damap.base.rest;
 
 import static io.restassured.RestAssured.given;
+import static org.damap.base.TestProfiles.DefaultProfile.ADMIN_ROLE;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -111,7 +112,7 @@ class InternalStorageResourceTest {
 
   // POST tests
   @Test
-  @TestSecurity(user = "adminJwt", roles = "Damap Admin")
+  @TestSecurity(user = "adminJwt", roles = ADMIN_ROLE)
   void testCreateEndpointAsAdminWithMissingTranslation_BadRequest() {
     InternalStorageDO invalidData = this.getValidInternalStorageDO();
     invalidData.setTranslations(List.of());
@@ -128,7 +129,7 @@ class InternalStorageResourceTest {
   }
 
   @Test
-  @TestSecurity(user = "adminJwt", roles = "Damap Admin")
+  @TestSecurity(user = "adminJwt", roles = ADMIN_ROLE)
   void testCreateEndpointAsAdminWithEmptyURL_BadRequest() {
     InternalStorageDO invalidData = this.getValidInternalStorageDO();
     invalidData.setUrl("");
@@ -148,7 +149,7 @@ class InternalStorageResourceTest {
   }
 
   @Test
-  @TestSecurity(user = "adminJwt", roles = "Damap Admin")
+  @TestSecurity(user = "adminJwt", roles = ADMIN_ROLE)
   void testCreateEndpointAsAdminWithValidData_Created() {
     InternalStorageDO validData = this.getValidInternalStorageDO();
 
@@ -177,7 +178,7 @@ class InternalStorageResourceTest {
 
   // PUT tests
   @Test
-  @TestSecurity(user = "adminJwt", roles = "Damap Admin")
+  @TestSecurity(user = "adminJwt", roles = ADMIN_ROLE)
   void testPutEndpointAsAdminWithNonExistingId_NotFound() {
     InternalStorageDO validData = this.getValidInternalStorageDO();
     given()
@@ -190,7 +191,7 @@ class InternalStorageResourceTest {
   }
 
   @Test
-  @TestSecurity(user = "adminJwt", roles = "Damap Admin")
+  @TestSecurity(user = "adminJwt", roles = ADMIN_ROLE)
   void testPutEndpointAsAdminValid_Updated() {
     Long id = testDOFactory.prepareInternalStorageOption();
 
@@ -219,13 +220,13 @@ class InternalStorageResourceTest {
 
   // DELETE tests
   @Test
-  @TestSecurity(user = "adminJwt", roles = "Damap Admin")
+  @TestSecurity(user = "adminJwt", roles = ADMIN_ROLE)
   void testDeleteEndpointAsAdminWithNonExistingId_NotFound() {
     given().when().delete("/-1").then().statusCode(404);
   }
 
   @Test
-  @TestSecurity(user = "adminJwt", roles = "Damap Admin")
+  @TestSecurity(user = "adminJwt", roles = ADMIN_ROLE)
   void testDeleteEndpointAsAdminValidId_Deleted() {
     Long id = testDOFactory.prepareInternalStorageOption();
     given().when().delete("/" + id).then().statusCode(204);

--- a/src/test/java/org/damap/base/rest/InternalStorageTranslationResourceTest.java
+++ b/src/test/java/org/damap/base/rest/InternalStorageTranslationResourceTest.java
@@ -1,6 +1,7 @@
 package org.damap.base.rest;
 
 import static io.restassured.RestAssured.given;
+import static org.damap.base.TestProfiles.DefaultProfile.ADMIN_ROLE;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -20,6 +21,8 @@ import org.junit.jupiter.api.Test;
 @TestHTTPEndpoint(InternalStorageTranslationResource.class)
 @TestProfile(TestProfiles.DefaultProfile.class)
 class InternalStorageTranslationResourceTest {
+
+  final String test = "damap-super-admin";
 
   @Inject TestDOFactory testDOFactory;
 
@@ -109,7 +112,7 @@ class InternalStorageTranslationResourceTest {
 
   // Create tests
   @Test
-  @TestSecurity(user = "adminJwt", roles = "Damap Admin")
+  @TestSecurity(user = "adminJwt", roles = ADMIN_ROLE)
   void testCreateTranslationInvalidStorageID_NotFound() {
     InternalStorageTranslationDO data = new InternalStorageTranslationDO();
     data.setStorageId(-1);
@@ -129,7 +132,7 @@ class InternalStorageTranslationResourceTest {
   }
 
   @Test
-  @TestSecurity(user = "adminJwt", roles = "Damap Admin")
+  @TestSecurity(user = "adminJwt", roles = ADMIN_ROLE)
   void testCreateTranslationDuplicateLanguageCode_BadRequest() {
 
     Long id = testDOFactory.prepareInternalStorageTranslationOption(false).get(0);
@@ -154,7 +157,7 @@ class InternalStorageTranslationResourceTest {
   }
 
   @Test
-  @TestSecurity(user = "adminJwt", roles = "Damap Admin")
+  @TestSecurity(user = "adminJwt", roles = test)
   void testCreateEndpointValidData_Created() {
     Long id = testDOFactory.prepareInternalStorageOption();
 
@@ -194,7 +197,7 @@ class InternalStorageTranslationResourceTest {
 
   // Update tests
   @Test
-  @TestSecurity(user = "adminJwt", roles = "Damap Admin")
+  @TestSecurity(user = "adminJwt", roles = ADMIN_ROLE)
   void testUpdateEndpointInvalidID_NotFound() {
     InternalStorageTranslationDO data = new InternalStorageTranslationDO();
     data.setTitle("Test Storage Title ENG");
@@ -213,7 +216,7 @@ class InternalStorageTranslationResourceTest {
   }
 
   @Test
-  @TestSecurity(user = "adminJwt", roles = "Damap Admin")
+  @TestSecurity(user = "adminJwt", roles = ADMIN_ROLE)
   void testUpdateEndpointValidData_Updated() {
     List<Long> ids = testDOFactory.prepareInternalStorageTranslationOption(false);
 
@@ -252,13 +255,13 @@ class InternalStorageTranslationResourceTest {
 
   // Delete tests
   @Test
-  @TestSecurity(user = "adminJwt", roles = "Damap Admin")
+  @TestSecurity(user = "adminJwt", roles = ADMIN_ROLE)
   void testDeleteEndpointInvalidID_NotFound() {
     given().pathParam("storageId", -1).when().delete("/-1").then().statusCode(404);
   }
 
   @Test
-  @TestSecurity(user = "adminJwt", roles = "Damap Admin")
+  @TestSecurity(user = "adminJwt", roles = ADMIN_ROLE)
   void testDeleteEndpointLastTranslation_BadRequest() {
     List<Long> ids = testDOFactory.prepareInternalStorageTranslationOption(false);
 
@@ -274,7 +277,7 @@ class InternalStorageTranslationResourceTest {
   }
 
   @Test
-  @TestSecurity(user = "adminJwt", roles = "Damap Admin")
+  @TestSecurity(user = "adminJwt", roles = ADMIN_ROLE)
   void testDeleteEndpointValidID_Deleted() {
     List<Long> id = testDOFactory.prepareInternalStorageTranslationOption(true);
     Long translationId = id.get(2);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
Feature

#### What does this PR do?

Adds support for an integration with EduId using an intermediary SAML translation setup with a keycloak interface (not included in the project). 
To support integrating with any keycloak, claims were made configurable and config options in `application.yaml` were renamed to be clearer and given corresponding environment variables to ease deployment.
For multitenant deployments, the affiliation is extracted from the claims, in the case of double affiliation, we return a 401.
Roles claims are now also configuable using a path, e.g. "realm_access/roles" in case of the test keycloak

Its a draft, so no documentation yet. I will add it after everything looks good and is reviewed.

#### Breaking changes
Incompatible with older frontends and older setups will need to change their configs.

#### Code review focus
Please check naming of variables - I hope everything is clearly named but a second opinion is wanted :)
I had to do a weird workaround with the tests regarding the admin-role-name property - I couldnt find a better way, maybe you have an idea.

#### Dependencies
https://github.com/damap-org/damap-frontend/pull/511

closes GH-411
