### PR TITLE
Gk/user management eduid

### DIFF
--- a/src/main/java/org/damap/base/domain/User.java
+++ b/src/main/java/org/damap/base/domain/User.java
@@ -1,0 +1,30 @@
+package org.damap.base.domain;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity(name = "damap_user")
+@Table(name = "damap_user")
+@EqualsAndHashCode(callSuper = true)
+public class User extends PanacheEntity {
+
+  @Column(name = "identifier", unique = true, nullable = false)
+  private String identifier;
+
+  @Column(name = "name")
+  private String name;
+
+  @Column(name = "first_name")
+  private String firstName;
+
+  @Column(name = "last_name")
+  private String lastName;
+
+  @Column(name = "email")
+  private String email;
+}

--- a/src/main/java/org/damap/base/repo/DamapUserRepo.java
+++ b/src/main/java/org/damap/base/repo/DamapUserRepo.java
@@ -1,0 +1,30 @@
+package org.damap.base.repo;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import io.quarkus.panache.common.Page;
+import io.quarkus.panache.common.Parameters;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.List;
+import org.damap.base.domain.User;
+
+@ApplicationScoped
+public class DamapUserRepo implements PanacheRepository<User> {
+
+  /** Find user list by match in name or email. */
+  public List<User> findUsersByNameOrEmailMatch(String match) {
+    if (match == null || match.isBlank()) {
+      return List.of();
+    }
+    String pattern = "%" + match.trim().toLowerCase() + "%";
+
+    return find(
+            "lower(name) like :pattern or lower(email) like :pattern",
+            Parameters.with("pattern", pattern))
+        .page(Page.ofSize(20))
+        .list();
+  }
+
+  public User findUserByIdentifier(String identifier) {
+    return find("identifier", identifier).firstResult();
+  }
+}

--- a/src/main/java/org/damap/base/rest/AccessResource.java
+++ b/src/main/java/org/damap/base/rest/AccessResource.java
@@ -8,8 +8,8 @@ import jakarta.ws.rs.core.MediaType;
 import java.util.List;
 import lombok.extern.jbosslog.JBossLog;
 import org.damap.base.rest.access.domain.AccessDO;
+import org.damap.base.rest.access.domain.UserDO;
 import org.damap.base.rest.access.service.AccessService;
-import org.damap.base.rest.dmp.domain.ContributorDO;
 import org.damap.base.validation.AccessValidator;
 
 /** AccessResource class. */
@@ -30,7 +30,7 @@ public class AccessResource {
    */
   @GET
   @Path("/dmps/{id}")
-  public List<ContributorDO> getAccessForDmp(@PathParam("id") String id) {
+  public List<AccessDO> getAccessForDmp(@PathParam("id") String id) {
     log.info("Return access list for dmp with id: " + id);
     long dmpId = Long.parseLong(id);
     if (!this.accessValidator.canViewAccess(dmpId)) {
@@ -50,7 +50,7 @@ public class AccessResource {
   public AccessDO create(@Valid AccessDO accessDO) {
     log.info("Create new access");
     // University id required for now, might change in the future
-    if (accessDO.getUniversityId() == null) {
+    if (accessDO.getIdentifier() == null) {
       throw new BadRequestException("University id is required");
     }
 
@@ -74,5 +74,12 @@ public class AccessResource {
       throw new ForbiddenException();
     }
     accessService.delete(accessId);
+  }
+
+  @GET
+  @Path("/user-search")
+  public List<UserDO> searchUsers(@QueryParam("q") String query) {
+    log.info("Search users with query: " + query);
+    return accessService.searchUserDO(query);
   }
 }

--- a/src/main/java/org/damap/base/rest/access/domain/AccessDO.java
+++ b/src/main/java/org/damap/base/rest/access/domain/AccessDO.java
@@ -6,23 +6,30 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.util.Date;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import org.damap.base.enums.EFunctionRole;
-import org.damap.base.rest.dmp.domain.ContributorDO;
 
 /** AccessDO class. */
 @Data
-@EqualsAndHashCode(callSuper = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class AccessDO extends ContributorDO {
+public class AccessDO {
+
+  private Long id;
 
   @NotNull @Positive private long dmpId;
 
-  @NotNull private EFunctionRole access;
+  @NotNull private EFunctionRole role;
 
   @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
   private Date start;
 
   @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
   private Date until;
+
+  private String identifier;
+
+  private String firstName;
+
+  private String lastName;
+
+  private String mbox;
 }

--- a/src/main/java/org/damap/base/rest/access/domain/UserDO.java
+++ b/src/main/java/org/damap/base/rest/access/domain/UserDO.java
@@ -1,0 +1,19 @@
+package org.damap.base.rest.access.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UserDO {
+
+  private String identifier;
+
+  private String name;
+
+  private String firstName;
+
+  private String lastName;
+
+  private String email;
+}

--- a/src/main/java/org/damap/base/rest/access/mapper/AccessMapper.java
+++ b/src/main/java/org/damap/base/rest/access/mapper/AccessMapper.java
@@ -1,14 +1,10 @@
 package org.damap.base.rest.access.mapper;
 
-import java.util.Optional;
 import lombok.experimental.UtilityClass;
 import org.damap.base.domain.Access;
-import org.damap.base.domain.Contributor;
 import org.damap.base.domain.Dmp;
-import org.damap.base.domain.Identifier;
+import org.damap.base.domain.User;
 import org.damap.base.rest.access.domain.AccessDO;
-import org.damap.base.rest.dmp.domain.IdentifierDO;
-import org.damap.base.rest.dmp.mapper.IdentifierDOMapper;
 import org.damap.base.rest.dmp.mapper.MapperService;
 
 /** AccessMapper class. */
@@ -22,30 +18,18 @@ public class AccessMapper {
    * @param accessDO a {@link org.damap.base.rest.access.domain.AccessDO} object
    * @return a {@link org.damap.base.rest.access.domain.AccessDO} object
    */
-  public AccessDO mapEntityToDO(Access access, AccessDO accessDO) {
+  public AccessDO mapEntityToDO(Access access, User user, AccessDO accessDO) {
     accessDO.setId(access.id);
     accessDO.setDmpId(access.getDmp().id);
-    accessDO.setUniversityId(access.getUniversityId());
-    // Get name and mail for accesses from contributor list
-    Optional<Contributor> contributor =
-        access.getDmp().getContributorList().stream()
-            .filter(
-                c ->
-                    c.getUniversityId() != null
-                        && c.getUniversityId().equals(access.getUniversityId()))
-            .findFirst();
-    if (contributor.isPresent()) {
-      Contributor c = contributor.get();
-      accessDO.setFirstName(c.getFirstName());
-      accessDO.setLastName(c.getLastName());
-      accessDO.setMbox(c.getMbox());
+    accessDO.setIdentifier(access.getUniversityId());
+
+    if (user != null) {
+      accessDO.setMbox(user.getEmail());
+      accessDO.setFirstName(user.getFirstName());
+      accessDO.setLastName(user.getLastName());
     }
-    if (access.getPersonIdentifier() != null) {
-      IdentifierDO identifierDO = new IdentifierDO();
-      IdentifierDOMapper.mapEntityToDO(access.getPersonIdentifier(), identifierDO);
-      accessDO.setPersonId(identifierDO);
-    }
-    accessDO.setAccess(access.getRole());
+
+    accessDO.setRole(access.getRole());
     accessDO.setStart(access.getStart());
     accessDO.setUntil(access.getUntil());
     return accessDO;
@@ -62,12 +46,9 @@ public class AccessMapper {
   public Access mapDOtoEntity(AccessDO accessDO, Access access, MapperService mapperService) {
     Dmp dmp = mapperService.getDmpById(accessDO.getDmpId());
     access.setDmp(dmp);
-    access.setRole(accessDO.getAccess());
-    access.setUniversityId(accessDO.getUniversityId());
-    if (accessDO.getPersonId() != null) {
-      access.setPersonIdentifier(
-          IdentifierDOMapper.mapDOtoEntity(accessDO.getPersonId(), new Identifier()));
-    }
+    access.setRole(accessDO.getRole());
+    access.setUniversityId(accessDO.getIdentifier());
+
     access.setStart(accessDO.getStart());
     access.setUntil(accessDO.getUntil());
     return access;

--- a/src/main/java/org/damap/base/rest/access/service/AccessService.java
+++ b/src/main/java/org/damap/base/rest/access/service/AccessService.java
@@ -1,7 +1,5 @@
 package org.damap.base.rest.access.service;
 
-import static org.damap.base.utils.EqualityUtils.nullExclusiveEquals;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -11,14 +9,13 @@ import java.util.List;
 import lombok.extern.jbosslog.JBossLog;
 import org.damap.base.domain.Access;
 import org.damap.base.domain.Dmp;
-import org.damap.base.integration.PersonService;
+import org.damap.base.domain.User;
 import org.damap.base.repo.AccessRepo;
+import org.damap.base.repo.DamapUserRepo;
 import org.damap.base.repo.DmpRepo;
-import org.damap.base.rest.PersonServiceBroker;
 import org.damap.base.rest.access.domain.AccessDO;
+import org.damap.base.rest.access.domain.UserDO;
 import org.damap.base.rest.access.mapper.AccessMapper;
-import org.damap.base.rest.dmp.domain.ContributorDO;
-import org.damap.base.rest.dmp.mapper.ContributorDOMapper;
 import org.damap.base.rest.dmp.mapper.MapperService;
 
 /** AccessService class. */
@@ -26,66 +23,33 @@ import org.damap.base.rest.dmp.mapper.MapperService;
 @JBossLog
 public class AccessService {
 
-  // defines which personService is to be used for access management
-  private final String ENABLED_PERSON_SERVICE = "UNIVERSITY";
-
   @Inject AccessRepo accessRepo;
 
   @Inject DmpRepo dmpRepo;
 
   @Inject MapperService mapperService;
 
-  @Inject PersonServiceBroker personServiceBroker;
+  @Inject DamapUserRepo damapUserRepo;
 
   /**
-   * getByDmpId.
+   * getByDmpId. Returns all users that have access to the DMP.
    *
    * @param dmpId a long
    * @return a {@link java.util.List} object
    */
-  public List<ContributorDO> getByDmpId(long dmpId) {
-    PersonService personService =
-        personServiceBroker.getServiceForQueryParam(ENABLED_PERSON_SERVICE);
-
+  public List<AccessDO> getByDmpId(long dmpId) {
     Dmp dmp = dmpRepo.findById(dmpId);
-    // Get access list (owner, editors)
-    List<ContributorDO> accessDOList = new ArrayList<>();
+    List<AccessDO> accessDOList = new ArrayList<>();
+
     accessRepo
         .getAccessByDmp(dmp)
         .forEach(
             access -> {
-              AccessDO accessDO = AccessMapper.mapEntityToDO(access, new AccessDO());
-              // Set owner/editor data. If they're not listed as a contributor, fields will be
-              // empty.
-              if (accessDO.getMbox() == null) {
-                // TODO: Handle case when owner is no longer at university
-                ContributorDO owner = personService.read(access.getUniversityId());
-                accessDO.setFirstName(owner.getFirstName());
-                accessDO.setLastName(owner.getLastName());
-                accessDO.setMbox(owner.getMbox());
-              }
+              User user = damapUserRepo.findUserByIdentifier(access.getUniversityId());
+              AccessDO accessDO = AccessMapper.mapEntityToDO(access, user, new AccessDO());
               accessDOList.add(accessDO);
             });
 
-    // Get dmp contributors (viewers)
-    dmp.getContributorList()
-        .forEach(
-            contributor -> {
-              // Only university members can be editors for now
-              if (contributor.getUniversityId() != null
-                  && !contributor.getUniversityId().isEmpty()
-                  && accessDOList.stream()
-                      .noneMatch(
-                          a ->
-                              nullExclusiveEquals(
-                                  a.getUniversityId(), contributor.getUniversityId()))) {
-                ContributorDO contributorDO = new ContributorDO();
-                ContributorDOMapper.mapEntityToDO(contributor, contributorDO);
-                // Set id null, so it's not confused with access id
-                contributorDO.setId(null);
-                accessDOList.add(contributorDO);
-              }
-            });
     return accessDOList;
   }
 
@@ -110,7 +74,10 @@ public class AccessService {
     }
     access.setStart(new Date());
     access.persist();
-    return AccessMapper.mapEntityToDO(access, new AccessDO());
+
+    User user = damapUserRepo.findUserByIdentifier(access.getUniversityId());
+
+    return AccessMapper.mapEntityToDO(access, user, new AccessDO());
   }
 
   /**
@@ -121,5 +88,22 @@ public class AccessService {
   @Transactional
   public void delete(long id) {
     accessRepo.deleteById(id);
+  }
+
+  public List<UserDO> searchUserDO(String match) {
+    List<UserDO> result = new ArrayList<>();
+    damapUserRepo
+        .findUsersByNameOrEmailMatch(match)
+        .forEach(
+            user -> {
+              UserDO userDO = new UserDO();
+              userDO.setIdentifier(user.getIdentifier());
+              userDO.setName(user.getName());
+              userDO.setFirstName(user.getFirstName());
+              userDO.setLastName(user.getLastName());
+              userDO.setEmail(user.getEmail());
+              result.add(userDO);
+            });
+    return result;
   }
 }

--- a/src/main/java/org/damap/base/rest/auth/UserSyncService.java
+++ b/src/main/java/org/damap/base/rest/auth/UserSyncService.java
@@ -1,0 +1,50 @@
+package org.damap.base.rest.auth;
+
+import io.quarkus.cache.CacheResult;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.damap.base.domain.User;
+import org.damap.base.repo.DamapUserRepo;
+
+/**
+ * This class is responsible for synchronizing user information from an external IDP (i.e Keycloak)
+ * to the database. It checks if a user with the given identifier exists, and if not, it creates a
+ * new user. If the user already exists, it updates the user's information. The return value of this
+ * method is cached for 1-2 hours for instance and allows to invoke this method less frequently, as
+ * the user information is not expected to change often (email, name, first name, last name).
+ */
+@ApplicationScoped
+public class UserSyncService {
+
+  @Inject DamapUserRepo userRepo;
+
+  @CacheResult(cacheName = "user-sync-cache")
+  @Transactional
+  public String syncUser(
+      String identifier, String email, String name, String firstName, String lastName) {
+
+    User user = userRepo.findUserByIdentifier(identifier);
+
+    if (user == null) {
+      // Create new
+      user =
+          User.builder()
+              .identifier(identifier)
+              .email(email)
+              .name(name)
+              .firstName(firstName)
+              .lastName(lastName)
+              .build();
+      userRepo.persist(user);
+    } else {
+      user.setEmail(email);
+      user.setName(name);
+      user.setFirstName(firstName);
+      user.setLastName(lastName);
+      userRepo.persist(user);
+    }
+
+    return identifier;
+  }
+}

--- a/src/main/java/org/damap/base/security/DamapSecurityAugmentor.java
+++ b/src/main/java/org/damap/base/security/DamapSecurityAugmentor.java
@@ -1,0 +1,64 @@
+package org.damap.base.security;
+
+import io.quarkus.oidc.runtime.OidcJwtCallerPrincipal;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.SecurityIdentityAugmentor;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.damap.base.rest.auth.UserSyncService;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+/**
+ * This Security Augmentor intercepts the authentication process to synchronize user data from the
+ * OIDC token (JWT) into the local database.
+ *
+ * <p>It extracts configurable user attributes (ID, email, name) from the principal's claims and
+ * delegates to {@link UserSyncService} to ensure the user record exists and is up-to-date.
+ */
+@ApplicationScoped
+public class DamapSecurityAugmentor implements SecurityIdentityAugmentor {
+
+  @Inject UserSyncService userSyncService;
+
+  @ConfigProperty(name = "damap.auth.user-id-claim", defaultValue = "sub")
+  String userIdClaim;
+
+  @ConfigProperty(name = "damap.auth.email-claim", defaultValue = "email")
+  String emailClaim;
+
+  @ConfigProperty(name = "damap.auth.name-claim", defaultValue = "name")
+  String nameClaim;
+
+  @ConfigProperty(name = "damap.auth.given-name-claim", defaultValue = "given_name")
+  String givenNameClaim;
+
+  @ConfigProperty(name = "damap.auth.family-name-claim", defaultValue = "family_name")
+  String familyNameClaim;
+
+  @Override
+  public Uni<SecurityIdentity> augment(
+      SecurityIdentity identity, AuthenticationRequestContext context) {
+    if (identity.isAnonymous()) {
+      return Uni.createFrom().item(identity);
+    }
+
+    if (identity.getPrincipal() instanceof OidcJwtCallerPrincipal jwt) {
+
+      String userId = jwt.getClaim(userIdClaim);
+      String email = jwt.getClaim(emailClaim);
+      String name = jwt.getClaim(nameClaim);
+      String firstName = jwt.getClaim(givenNameClaim);
+      String lastName = jwt.getClaim(familyNameClaim);
+
+      return context.runBlocking(
+          () -> {
+            userSyncService.syncUser(userId, email, name, firstName, lastName);
+            return identity;
+          });
+    }
+
+    return Uni.createFrom().item(identity);
+  }
+}

--- a/src/main/java/org/damap/base/validation/AccessValidator.java
+++ b/src/main/java/org/damap/base/validation/AccessValidator.java
@@ -2,14 +2,13 @@ package org.damap.base.validation;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.damap.base.domain.Access;
-import org.damap.base.domain.Contributor;
 import org.damap.base.domain.Dmp;
 import org.damap.base.enums.EFunctionRole;
 import org.damap.base.repo.AccessRepo;
+import org.damap.base.repo.DamapUserRepo;
 import org.damap.base.repo.DmpRepo;
 import org.damap.base.rest.access.domain.AccessDO;
 import org.damap.base.security.SecurityService;
@@ -23,6 +22,8 @@ public class AccessValidator {
   @Inject DmpRepo dmpRepo;
 
   @Inject SecurityService securityService;
+
+  @Inject DamapUserRepo userRepo;
 
   /**
    * canViewDmp.
@@ -206,26 +207,13 @@ public class AccessValidator {
     return true;
   }
 
-  // Can the selected user be given access to this dmp
-  // Can be overwritten if necessary
-  // current implementation allows only institutional personnel which are also contributors
   /**
-   * canGetAccess.
+   * canGetAccess. Checks if the user we are trying to add actually exists in our system.
    *
    * @param accessDO a {@link org.damap.base.rest.access.domain.AccessDO} object
    * @return a boolean
    */
   public boolean canGetAccess(AccessDO accessDO) {
-    Dmp dmp = dmpRepo.findById(accessDO.getDmpId());
-    List<Contributor> contributors = dmp == null ? new ArrayList<>() : dmp.getContributorList();
-    // Check if new access is for a contributor
-    Optional<Contributor> contributor =
-        contributors.stream()
-            .filter(
-                c ->
-                    c.getUniversityId() != null
-                        && c.getUniversityId().equals(accessDO.getUniversityId()))
-            .findAny();
-    return contributor.isPresent();
+    return userRepo.findUserByIdentifier(accessDO.getIdentifier()) != null;
   }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -115,6 +115,10 @@ quarkus:
         expire-after-write: P1D
       "repository":
         expire-after-write: P1D
+      "user-sync-cache":
+        initial-capacity: 100
+        maximum-size: 1000
+        expire-after-write: 12H
 
   liquibase:
     migrate-at-start: true

--- a/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.7.0_2.yaml
+++ b/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.7.0_2.yaml
@@ -1,0 +1,42 @@
+databaseChangeLog:
+  - changeSet:
+      id: 26
+      author: Geoffrey Karnbach
+      changes:
+        - createSequence:
+            sequenceName: damap_user_seq
+            startValue: 1
+            incrementBy: 50
+
+        - createTable:
+            tableName: damap_user
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  constraints:
+                    primaryKey: true
+              - column:
+                  name: identifier
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+                    unique: true
+              - column:
+                  name: name
+                  type: VARCHAR(255)
+              - column:
+                  name: first_name
+                  type: VARCHAR(255)
+              - column:
+                  name: last_name
+                  type: VARCHAR(255)
+              - column:
+                  name: email
+                  type: VARCHAR(255)
+
+      rollback:
+        - dropTable:
+            tableName: damap_user
+        - dropSequence:
+            sequenceName: damap_user_seq

--- a/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.x.yaml
+++ b/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.x.yaml
@@ -31,4 +31,5 @@ databaseChangeLog:
       file: org/damap/base/db/changeLog-4.x/changeLog-4.5.2_3.yaml
   - include:
       file: org/damap/base/db/changeLog-4.x/changeLog-4.7.0_1.yaml
-
+  - include:
+      file: org/damap/base/db/changeLog-4.x/changeLog-4.7.0_2.yaml

--- a/src/test/java/org/damap/base/TestSetup.java
+++ b/src/test/java/org/damap/base/TestSetup.java
@@ -4,10 +4,12 @@ import static org.mockito.ArgumentMatchers.any;
 
 import io.quarkus.test.InjectMock;
 import jakarta.inject.Inject;
+import org.damap.base.domain.User;
 import org.damap.base.integration.mock.MockProjectServiceImpl;
 import org.damap.base.integration.mock.MockUniversityPersonServiceImpl;
 import org.damap.base.integration.orcid.ORCIDMapper;
 import org.damap.base.integration.orcid.ORCIDPersonServiceImpl;
+import org.damap.base.repo.DamapUserRepo;
 import org.damap.base.rest.dmp.domain.DmpDO;
 import org.damap.base.security.SecurityService;
 import org.damap.base.util.TestDOFactory;
@@ -27,6 +29,8 @@ public class TestSetup {
 
   @InjectMock MockProjectServiceImpl projectService;
 
+  @InjectMock protected DamapUserRepo userRepo;
+
   protected DmpDO dmpDO;
 
   /**
@@ -42,6 +46,8 @@ public class TestSetup {
         .thenReturn(ORCIDMapper.mapRecordEntityToPersonDO(testDOFactory.getORCIDTestRecord()));
     Mockito.when(projectService.getProjectLeader(any()))
         .thenReturn(testDOFactory.getTestContributorDO());
+    Mockito.when(userRepo.findUserByIdentifier(any(String.class)))
+        .thenReturn(new User("012345", "testUser", "Test User", "Test", "User"));
     dmpDO = testDOFactory.getOrCreateTestDmpDO();
   }
 }

--- a/src/test/java/org/damap/base/rest/AccessResourceTest.java
+++ b/src/test/java/org/damap/base/rest/AccessResourceTest.java
@@ -15,7 +15,6 @@ import org.damap.base.TestSetup;
 import org.damap.base.enums.EFunctionRole;
 import org.damap.base.rest.access.domain.AccessDO;
 import org.damap.base.rest.access.service.AccessService;
-import org.damap.base.rest.dmp.domain.ContributorDO;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -86,21 +85,6 @@ class AccessResourceTest extends TestSetup {
 
   @Test
   @TestSecurity(user = "userJwt", roles = "user")
-  void testCreateAccessNoContributor_InValid() {
-    AccessDO accessDO = this.createAccessDO();
-    accessDO.setUniversityId("234567");
-
-    given()
-        .contentType(MediaType.APPLICATION_JSON)
-        .body(accessDO)
-        .when()
-        .post("/")
-        .then()
-        .statusCode(403);
-  }
-
-  @Test
-  @TestSecurity(user = "userJwt", roles = "user")
   void testCreateAccessNoPermission_Invalid() {
     Mockito.when(securityService.getUserId()).thenReturn("234567");
     AccessDO accessDO = this.createAccessDO();
@@ -135,15 +119,15 @@ class AccessResourceTest extends TestSetup {
   @TestSecurity(user = "userJwt", roles = "user")
   void testDeleteAccess_Invalid() {
     Mockito.when(securityService.getUserId()).thenReturn("234567");
-    ContributorDO accessDO = this.accessService.getByDmpId(dmpDO.getId()).get(0);
+    AccessDO accessDO = this.accessService.getByDmpId(dmpDO.getId()).get(0);
     given().when().delete("/" + accessDO.getId()).then().statusCode(403);
   }
 
   private AccessDO createAccessDO() {
     AccessDO accessDO = new AccessDO();
     accessDO.setDmpId(dmpDO.getId());
-    accessDO.setUniversityId(dmpDO.getContributors().get(0).getUniversityId());
-    accessDO.setAccess(EFunctionRole.EDITOR);
+    accessDO.setIdentifier(dmpDO.getContributors().get(0).getUniversityId());
+    accessDO.setRole(EFunctionRole.EDITOR);
     return accessDO;
   }
 }


### PR DESCRIPTION
## Description
This PR decouples access management from project contributors by introducing a local user persistence layer. It ensures user data used for access control is stored consistently in the database rather than relying on external services or transient metadata.

#### What does this PR do?
* **User Persistence:** Adds `damap_user` table and repository to store user identity and metadata.
* **Auth Sync:** Implements `DamapSecurityAugmentor` to synchronize user data from OIDC tokens to the database upon authentication. Includes caching to minimize database writes.
* **Access Refactoring:**
    * Decouples `AccessDO` from `ContributorDO` (removes inheritance).
    * Updates `AccessService` to return only explicit access entries; contributors are no longer merged into the response.
    * Renames `universityId` to `identifier` and `access` to `role` in `AccessDO`.
* **Search:** Adds `GET /api/access/user-search` to search registered users by name or email.

#### Breaking changes
* `AccessDO` structure updated (fields renamed, inheritance removed).
* `GET /api/access/dmps/{id}` now returns `List<AccessDO>` instead of `List<ContributorDO>`.
* Contributors listed in a DMP do not implicitly receive access rights anymore; access must be explicitly granted.

#### Code review focus
* `UserSyncService` and `DamapSecurityAugmentor` for synchronization logic.
* `AccessService.getByDmpId` for the removal of the contributor merge logic.
* `AccessMapper` for the updated field mapping.

#### Dependencies
Frontend PR: https://github.com/damap-org/damap-frontend/pull/514

### Checks
- [ ] Tested with Oracle/PostgreSQL
- [ ] Export updated
- [x] Documentation added
- [x] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-