### PR TITLE
Repair Docker ignore file for build time and security

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 !target/*-runner
 !target/*-runner.jar
 !target/lib/*
+!docker/docker-entrypoint.sh


### PR DESCRIPTION
## Description
<!-- Please select a type that best describes your PR -->
<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->
Bugfix

**Context:**
When building a Docker image, the entire project directory is sent to the Docker daemon (which acts as a server) as the build context. This is unless we specify a different behavior in a `.dockerignore` file. The default behaviour without this file can be bad both for build times and security, since we send over heavy files like the entire git history and in some cases sensitive files like environment variables to another process unnecessarily. 
For more context: https://codefresh.io/blog/not-ignore-dockerignore-2/

A little over 4 years ago, `.dockerignore` got renamed to `.dockerignore.tmp`. Docker will therefore ignore this file, which puts us in the situation above.


#### What does this PR do?
<!-- Changes introduced by this PR - what happened before, what happens now -->
- renamed `.dockerfile.tmp` to `.dockerfile`
- added the whitelist rule `!docker/docker-entrypoint.sh`. This is because the entrypoint file is needed as specified in the Dockerfile.

#### Breaking changes
<!-- Whether this PR contains breaking changes and which -->

closes GH-456<!-- insert issue number -->
