### PR TITLE
Pure: Fix endless loop in listAll

### DIFF
--- a/src/main/java/org/damap/base/integration/pure/PureAPI.java
+++ b/src/main/java/org/damap/base/integration/pure/PureAPI.java
@@ -56,10 +56,10 @@ interface PureAPI {
     while (!finished) {
       PureAPIPaginatedProjectsResponse projects = listAllProjects(pageSize, offset);
       items.addAll(projects.items);
-      if (projects.count <= projects.pageInformation.offset + projects.pageInformation.size) {
+      offset = projects.pageInformation.offset + projects.pageInformation.size;
+      if (projects.count <= offset) {
         finished = true;
       }
-      offset = projects.pageInformation.offset;
     }
     return items;
   }
@@ -77,10 +77,10 @@ interface PureAPI {
     while (!finished) {
       PureAPIPaginatedPersonsResponse persons = listAllPersons(pageSize, offset);
       items.addAll(persons.items);
-      if (persons.count <= persons.pageInformation.offset + persons.pageInformation.size) {
+      offset = persons.pageInformation.offset + persons.pageInformation.size;
+      if (persons.count <= offset) {
         finished = true;
       }
-      offset = persons.pageInformation.offset;
     }
     return items;
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
Bugfix

#### What does this PR do?
Fixes a Bug where listallPersons/Projects enters an endless loop, due to the offset not being upated correctly. I returned the fucntions to their original implementations, seems like they got changed during the long development process.
