### PR TITLE
Config: Refactor to use .env instead of application.yaml for configur…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ release.properties
 
 # Quarkus
 .quarkus
+
+# Environment files
+.env

--- a/docker/docker-compose.oracle.yaml
+++ b/docker/docker-compose.oracle.yaml
@@ -15,10 +15,10 @@ services:
       QUARKUS_HIBERNATE_ORM_DIALECT: "org.hibernate.dialect.OracleDialect"
       QUARKUS_DATASOURCE_JDBC_DRIVER: "oracle.jdbc.driver.OracleDriver"
       QUARKUS_DATASOURCE_DB_KIND: "oracle"
-      QUARKUS_DATASOURCE_USERNAME: "damap"
-      QUARKUS_DATASOURCE_PASSWORD: "pw4damap"
+      QUARKUS_DATASOURCE_USERNAME: ${QUARKUS_DATASOURCE_USERNAME:-damap}
+      QUARKUS_DATASOURCE_PASSWORD: ${QUARKUS_DATASOURCE_PASSWORD:-pw4damap}
     volumes:
-      - ./tenants.yaml://opt/damap/tenants.yaml:ro
+      - ./tenants.yaml:/opt/damap/tenants.yaml:ro
     depends_on:
       - damap-db
       - keycloak

--- a/docker/docker-compose.oracle.yaml
+++ b/docker/docker-compose.oracle.yaml
@@ -10,15 +10,13 @@ services:
       context: ../
     restart: unless-stopped
     environment:
-      DAMAP_TITLE: "DAMAP Tool"
-      DAMAP_DATASOURCE_URL: "jdbc:oracle:thin:@damap-db:1521/FREEPDB1"
-      DAMAP_DATASOURCE_DIALECT: "org.hibernate.dialect.OracleDialect"
-      DAMAP_DATASOURCE_DRIVER: "oracle.jdbc.driver.OracleDriver"
-      DAMAP_DATASOURCE_DB_KIND: "oracle"
-      DAMAP_DATASOURCE_USERNAME: "damap"
-      DAMAP_DATASOURCE_PASSWORD: "pw4damap"
       QUARKUS_PROFILE: ${QUARKUS_PROFILE}
-      DAMAP_MULTITENANT_CONFIG: /opt/damap/tenants.yaml
+      QUARKUS_DATASOURCE_JDBC_URL: "jdbc:oracle:thin:@damap-db:1521/FREEPDB1"
+      QUARKUS_HIBERNATE_ORM_DIALECT: "org.hibernate.dialect.OracleDialect"
+      QUARKUS_DATASOURCE_JDBC_DRIVER: "oracle.jdbc.driver.OracleDriver"
+      QUARKUS_DATASOURCE_DB_KIND: "oracle"
+      QUARKUS_DATASOURCE_USERNAME: "damap"
+      QUARKUS_DATASOURCE_PASSWORD: "pw4damap"
     volumes:
       - ./tenants.yaml://opt/damap/tenants.yaml:ro
     depends_on:

--- a/docker/docker-compose.postgres.yaml
+++ b/docker/docker-compose.postgres.yaml
@@ -10,13 +10,11 @@ services:
       context: ../
     restart: unless-stopped
     environment:
-      DAMAP_TITLE: "DAMAP Tool"
-      DAMAP_DATASOURCE_URL: "jdbc:postgresql://damap-db:5432/damap"
-      DAMAP_DATASOURCE_DB_KIND: "postgresql"
-      DAMAP_DATASOURCE_USERNAME: "damap"
-      DAMAP_DATASOURCE_PASSWORD: "pw4damap"
       QUARKUS_PROFILE: ${QUARKUS_PROFILE}
-      DAMAP_MULTITENANT_CONFIG: /opt/damap/tenants.yaml
+      QUARKUS_DATASOURCE_JDBC_URL: "jdbc:postgresql://damap-db:5432/damap"
+      QUARKUS_DATASOURCE_DB_KIND: "postgresql"
+      QUARKUS_DATASOURCE_USERNAME: "damap"
+      QUARKUS_DATASOURCE_PASSWORD: "pw4damap"
     volumes:
       - ./tenants.yaml://opt/damap/tenants.yaml:ro
     depends_on:

--- a/docker/docker-compose.postgres.yaml
+++ b/docker/docker-compose.postgres.yaml
@@ -13,10 +13,10 @@ services:
       QUARKUS_PROFILE: ${QUARKUS_PROFILE}
       QUARKUS_DATASOURCE_JDBC_URL: "jdbc:postgresql://damap-db:5432/damap"
       QUARKUS_DATASOURCE_DB_KIND: "postgresql"
-      QUARKUS_DATASOURCE_USERNAME: "damap"
-      QUARKUS_DATASOURCE_PASSWORD: "pw4damap"
+      QUARKUS_DATASOURCE_USERNAME: ${QUARKUS_DATASOURCE_USERNAME:-damap}
+      QUARKUS_DATASOURCE_PASSWORD: ${QUARKUS_DATASOURCE_PASSWORD:-pw4damap}
     volumes:
-      - ./tenants.yaml://opt/damap/tenants.yaml:ro
+      - ./tenants.yaml:/opt/damap/tenants.yaml:ro
     depends_on:
       - damap-db
       - keycloak

--- a/docker/example.env
+++ b/docker/example.env
@@ -1,2 +1,111 @@
+## =====================
+## General configurations
+## =====================
+
 # Comma seperated profiles, defaults to prod if left empty
 QUARKUS_PROFILE=
+# Sets the HTML title of the frontend
+DAMAP_TITLE="DAMAP Tool"
+# Sets the frontends mode, should always be PROD for production environment
+# Allowed values:
+#   - DEV
+#   - PROD
+DAMAP_ENV=DEV
+# Comma-separated list of allowed browser origins for CORS
+QUARKUS_HTTP_CORS_ORIGINS=https://your.frontend.com,https://*.yourdomain.com
+# Sets the project service used, should only be set to elsevier-pure when a pure integraion is used
+# Allowed values:
+#   - default
+#   - elsevier-pure
+DAMAP_PROJECTS_SERVICE=default
+
+## =====================
+## Authentication
+## =====================
+
+# Configures the OIDC realm the DAMAP backend should query to verify authentication
+QUARKUS_OIDC_AUTH_SERVER_URL=http://localhost:8087/realms/damap
+# Configures the OIDC URL the frontend should send users to in order to log in. This is typically the same
+# as QUARKUS_OIDC_AUTH_SERVER_URL, but may differ if the backend can access the OIDC server over a non-public network
+QUARKUS_OIDC_ISSUER=http://localhost:8087/realms/damap
+# Client ID as configured in the OIDC Server
+QUARKUS_OIDC_CLIENT_ID=damap
+# Scopes to request during login
+DAMAP_AUTH_SCOPES="openid profile affiliation"
+# The OIDC claim path that will hold your DAMAP roles in the access token
+# Also accepts paths, e.g. "realm_access/roles"
+DAMAP_AUTH_USER_ROLES_CLAIM_PATH=roles
+# The OIDC claim to use as a user ID
+DAMAP_AUTH_USER_ID_CLAIM=sub
+# The OIDC claim that holds the users full name
+DAMAP_AUTH_NAME_CLAIM=name
+# The OIDC claim that holds the users given name
+DAMAP_AUTH_GIVEN_NAME_CLAIM=given_name
+# The OIDC claim that holds the users family name
+DAMAP_AUTH_FAMILY_NAME_CLAIM=family_name
+# The OIDC claim that holds the users email
+DAMAP_AUTH_EMAIL_CLAIM=email
+# The OIDC claim that holds the users affiliations
+DAMAP_AUTH_AFFILIATIONS_CLAIM=affiliation
+# Role name used to identify DAMAP super admins
+# If DAMAP is locally deployed and the variable is not set to damap-super-admin, ADMIN_ROLE constant in the
+# DefaultProfile test profile needs to be changed accordingly, otherwise the tests fail
+DAMAP_AUTH_ADMIN_ROLE_NAME=damap-super-admin
+
+## =====================
+## Databases
+## =====================
+
+# URL of the database
+QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://damap-db:5432/damap
+# Type of database driver
+QUARKUS_DATASOURCE_JDBC_DRIVER=org.postgresql.Driver
+# Type of database
+QUARKUS_DATASOURCE_DB_KIND=postgresql
+# Database username
+QUARKUS_DATASOURCE_USERNAME=damap
+# Database password
+QUARKUS_DATASOURCE_PASSWORD=pw4damap
+# Database dialect
+QUARKUS_HIBERNATE_ORM_DIALECT=org.hibernate.dialect.PostgreSQLDialect
+
+## =====================
+## REST
+## =====================
+
+QUARKUS_REST_FITS_MP_REST_URL=http://fits-service:8080/fits
+QUARKUS_GOTENBERG_MP_REST_URL=http://gotenberg:3000
+
+
+## =====================
+## Fields
+## =====================
+
+DAMAP_FIELDS_ETHICAL_REPORT_ENABLED=true
+
+## =====================
+## Elsevier PURE
+## =====================
+
+# The following settings map Pure classification URIs to DAMAP properties. Pure classification URIs start with
+# /dk/atira/pure, but are otherwise specific to the institutional setup in Pure.
+
+# The project description field DAMAP should use:
+ELSEVIER_PURE_DESCRIPTION_CLASSIFICATION: /dk/atira/pure/projectdescription
+# How Pure project contributor classifications map to DAMAP:
+ELSEVIER_PURE_CONTRIBUTOR_ROLE_CLASSIFICATIONS_DK_ATIRA_PURE_MEMBER: PROJECT_MEMBER
+# Which Pure classification should be read as the project lead:
+ELSEVIER_PURE_PROJECT_LEAD_CLASSIFICATIONS: /dk/atira/pure/projectlead
+# Configures if data should be fetched over http or from local files - should always be http for PROD:
+# Allowed values:
+#   - http
+#   - file
+ELSEVIER_PURE_BACKEND: http
+# URL to fetch data from, only relevant when ELSEVIER_PURE_BACKEND is set to http
+ELSEVIER_PURE_ENDPOINT_URL: "https://your-pure-instance.elsevierpure.com/ws/api"
+# API key used to authenticate over the PURE API, only relevant when ELSEVIER_PURE_BACKEND is set to http
+ELSEVIER_PURE_API_KEY: "your API key here"
+# location of projects file, only relevant when ELSEVIER_PURE_BACKEND is set to file
+ELSEVIER_PURE_PROJECTS_FILE: "file:///path/to/projects.json"
+# location of persons file, only relevant when ELSEVIER_PURE_BACKEND is set to file
+ELSEVIER_PURE_PERSONS_FILE: "file:///path/to/persons.json"

--- a/docker/example.env
+++ b/docker/example.env
@@ -34,10 +34,10 @@ DAMAP_PERSON_SERVICE_CLASS_NAME=org.damap.base.integration.mock.MockUniversityPe
 ## =====================
 
 # Configures the OIDC realm the DAMAP backend should query to verify authentication
-QUARKUS_OIDC_AUTH_SERVER_URL=http://localhost:8080/realms/damap
+QUARKUS_OIDC_AUTH_SERVER_URL=http://keycloak:8080/realms/damap
 # Configures the OIDC URL the frontend should send users to in order to log in. This is typically the same
 # as QUARKUS_OIDC_AUTH_SERVER_URL, but may differ if the backend can access the OIDC server over a non-public network
-QUARKUS_OIDC_ISSUER=http://localhost:8087/realms/damap
+QUARKUS_OIDC_TOKEN_ISSUER=http://localhost:8087/realms/damap
 # Client ID as configured in the OIDC Server
 QUARKUS_OIDC_CLIENT_ID=damap
 # Scopes to request during login

--- a/docker/example.env
+++ b/docker/example.env
@@ -12,31 +12,41 @@ DAMAP_TITLE="DAMAP Tool"
 #   - PROD
 DAMAP_ENV=DEV
 # Comma-separated list of allowed browser origins for CORS
-QUARKUS_HTTP_CORS_ORIGINS=https://your.frontend.com,https://*.yourdomain.com
-# Sets the project service used, should only be set to elsevier-pure when a pure integraion is used
+QUARKUS_HTTP_CORS_ORIGINS=http://localhost:8085
+# Sets the project service used, should be set to elsevier-pure only when pure integration is used
 # Allowed values:
 #   - default
 #   - elsevier-pure
 DAMAP_PROJECTS_SERVICE=default
-
+# Text shown in the frontend to allow users to switch between person services
+DAMAP_PERSON_SERVICE_DISPLAY_TEXT=University
+# Sets which person service is used
+# Allowed values:
+#   - UNIVERSITY
+#   - PURE
+DAMAP_PERSON_SERVICE_QUERY_VALUE=UNIVERSITY
+# Which java class is to be used as person service
+# Set to org.damap.base.integration.pure.PurePersonService for PURE
+# Or to your custom class, if you do use a custom integration
+DAMAP_PERSON_SERVICE_CLASS_NAME=org.damap.base.integration.mock.MockUniversityPersonServiceImpl
 ## =====================
 ## Authentication
 ## =====================
 
 # Configures the OIDC realm the DAMAP backend should query to verify authentication
-QUARKUS_OIDC_AUTH_SERVER_URL=http://localhost:8087/realms/damap
+QUARKUS_OIDC_AUTH_SERVER_URL=http://localhost:8080/realms/damap
 # Configures the OIDC URL the frontend should send users to in order to log in. This is typically the same
 # as QUARKUS_OIDC_AUTH_SERVER_URL, but may differ if the backend can access the OIDC server over a non-public network
 QUARKUS_OIDC_ISSUER=http://localhost:8087/realms/damap
 # Client ID as configured in the OIDC Server
 QUARKUS_OIDC_CLIENT_ID=damap
 # Scopes to request during login
-DAMAP_AUTH_SCOPES="openid profile affiliation"
+DAMAP_AUTH_SCOPES="openid profile email offline_access microprofile-jwt roles personID"
 # The OIDC claim path that will hold your DAMAP roles in the access token
 # Also accepts paths, e.g. "realm_access/roles"
-DAMAP_AUTH_USER_ROLES_CLAIM_PATH=roles
+DAMAP_AUTH_USER_ROLES_CLAIM_PATH=realm_access/roles
 # The OIDC claim to use as a user ID
-DAMAP_AUTH_USER_ID_CLAIM=sub
+DAMAP_AUTH_USER_ID_CLAIM=personID
 # The OIDC claim that holds the users full name
 DAMAP_AUTH_NAME_CLAIM=name
 # The OIDC claim that holds the users given name
@@ -50,7 +60,7 @@ DAMAP_AUTH_AFFILIATIONS_CLAIM=affiliation
 # Role name used to identify DAMAP super admins
 # If DAMAP is locally deployed and the variable is not set to damap-super-admin, ADMIN_ROLE constant in the
 # DefaultProfile test profile needs to be changed accordingly, otherwise the tests fail
-DAMAP_AUTH_ADMIN_ROLE_NAME=damap-super-admin
+DAMAP_AUTH_ADMIN_ROLE_NAME='DAMAP ADMIN'
 
 ## =====================
 ## Databases

--- a/docker/tenants.yaml
+++ b/docker/tenants.yaml
@@ -5,17 +5,9 @@ tenants: ['tenant_1', 'tenant_2']
       tenant_1:
         jdbc:
           url: jdbc:postgresql://damap-db:5432/tenant_1
-          driver: ${damap.datasource.driver}
-        db-kind: ${damap.datasource.db-kind}
-        username: ${damap.datasource.username}
-        password: ${damap.datasource.password}
       tenant_2:
         jdbc:
           url: jdbc:postgresql://damap-db:5432/tenant_2
-          driver: ${damap.datasource.driver}
-        db-kind: ${damap.datasource.db-kind}
-        username: ${damap.datasource.username}
-        password: ${damap.datasource.password}
 
     liquibase:
       tenant_1:

--- a/src/main/java/org/damap/base/rest/ConfigResource.java
+++ b/src/main/java/org/damap/base/rest/ConfigResource.java
@@ -54,10 +54,10 @@ public class ConfigResource {
   @ConfigProperty(name = "damap.person-services")
   PersonServiceConfigurations personServiceConfigurations;
 
-  @ConfigProperty(name = "quarkus.rest.fits/mp-rest/url")
+  @ConfigProperty(name = "rest.fits/mp-rest/url")
   Optional<URL> fitsUrl;
 
-  @ConfigProperty(name = "quarkus.rest.gotenberg/mp-rest/url")
+  @ConfigProperty(name = "rest.gotenberg/mp-rest/url")
   Optional<URL> gotenbergUrl;
 
   @ConfigProperty(name = "damap.fields.ethical-report-enabled")

--- a/src/main/java/org/damap/base/rest/ConfigResource.java
+++ b/src/main/java/org/damap/base/rest/ConfigResource.java
@@ -18,10 +18,10 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 @PermitAll
 @JBossLog
 public class ConfigResource {
-  @ConfigProperty(name = "damap.auth.server-url")
+  @ConfigProperty(name = "quarkus.oidc.token.issuer")
   String issuer;
 
-  @ConfigProperty(name = "damap.auth.clientID")
+  @ConfigProperty(name = "quarkus.oidc.client-id")
   String clientID;
 
   @ConfigProperty(name = "damap.auth.scope")
@@ -54,10 +54,10 @@ public class ConfigResource {
   @ConfigProperty(name = "damap.person-services")
   PersonServiceConfigurations personServiceConfigurations;
 
-  @ConfigProperty(name = "damap.fits-url")
+  @ConfigProperty(name = "quarkus.rest.fits/mp-rest/url")
   Optional<URL> fitsUrl;
 
-  @ConfigProperty(name = "damap.gotenberg-url")
+  @ConfigProperty(name = "quarkus.rest.gotenberg/mp-rest/url")
   Optional<URL> gotenbergUrl;
 
   @ConfigProperty(name = "damap.fields.ethical-report-enabled")

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,11 +5,11 @@ damap:
   env: DEV # override in your custom project with PROD for production deployment
   auth:
     # Scopes to request during login:
-    scope: openid profile affiliation
+    scope: openid profile email offline_access microprofile-jwt roles personID
     # The OIDC claim path that will hold your DAMAP roles in the access token
-    user-roles-claim-path: roles
+    user-roles-claim-path: realm_access/roles
     # The OIDC claim to use as a user ID:
-    user-id-claim: sub
+    user-id-claim: personID
     # The OIDC claim that holds the users full name
     name-claim: name
     # The OIDC claim that holds the users given name
@@ -21,9 +21,9 @@ damap:
     # The OIDC claim that holds the users affiliations
     affiliations-claim: affiliation
     # Role name used to identify DAMAP super admins
-    # If DAMAP is locally deployed and the variable is not set to damap-super-admin, ADMIN_ROLE constant in the
-    # DefaultProfile test profile needs to be changed accordingly, otherwise the tests fail
-    admin-role-name: damap-super-admin
+    # If DAMAP is locally deployed ADMIN_ROLE constant in the DefaultProfile test profile needs to be
+    # the same as here, otherwise the tests fail
+    admin-role-name: DAMAP ADMIN
   repositories:
     # Zenodo, Open Science Framework, DRYAD, Mendeley Data
     # can also be [] for no repositories recommendation
@@ -80,7 +80,7 @@ quarkus:
   http:
     cors:
       ~: true
-      origins: https://your.frontend.com
+      origins: http://localhost:8085
       headers: origin,content-type,accept,authorization
       access-control-max-age: 1
     # needed for the fits service. Specify how large a single file for upload may be.
@@ -88,7 +88,7 @@ quarkus:
       max-body-size: 10M
 
   oidc:
-    auth-server-url: http://localhost:8087/realms/damap
+    auth-server-url: http://localhost:8080/realms/damap
     client-id: damap
     token:
       issuer: http://localhost:8087/realms/damap
@@ -147,11 +147,6 @@ rest:
 "%dev":
   damap:
     title: "DAMAP (Development)"
-    auth:
-      scope: 'openid profile email offline_access microprofile-jwt roles personID'
-      user-id-claim: personID
-      user-roles-claim-path: realm_access/roles
-      admin-role-name: Damap Admin
 
   quarkus:
     http:
@@ -160,11 +155,8 @@ rest:
 
     oidc:
       auth-server-url: http://localhost:8087/realms/damap
-      client-id: damap
       token:
         issuer: http://localhost:8087/realms/damap
-      roles:
-        role-claim-path: ${damap.auth.user-roles-claim-path}
 
     # FOR ORACLE INSTEAD USE:
     #      url: jdbc:oracle:thin:@localhost:8088/FREEPDB1
@@ -177,11 +169,11 @@ rest:
       username: damap
       password: pw4damap
 
-    rest:
-      fits/mp-rest/url: http://localhost:8089/fits
-      gotenberg/mp-rest/url: http://localhost:3000
-      mock-projects/mp-rest/url: http://localhost:8091
-      mock-persons/mp-rest/url: http://localhost:8091
+  rest:
+    fits/mp-rest/url: http://localhost:8089/fits
+    gotenberg/mp-rest/url: http://localhost:3000
+    mock-projects/mp-rest/url: http://localhost:8091
+    mock-persons/mp-rest/url: http://localhost:8091
 
 "%test":
   damap:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -88,7 +88,7 @@ quarkus:
       max-body-size: 10M
 
   oidc:
-    auth-server-url: http://localhost:8080/realms/damap
+    auth-server-url: http://keycloak:8080/realms/damap
     client-id: damap
     token:
       issuer: http://localhost:8087/realms/damap

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,15 +3,7 @@
 damap:
   title: DAMAP Tool
   env: DEV # override in your custom project with PROD for production deployment
-  origins: http://localhost:8085 # https://your.frontend.com,https://*.yourdomain.com
   auth:
-    # Configures the OIDC realm the DAMAP backend should query to verify authentication:
-    server-url: http://localhost:8087/realms/damap
-    # Configures the OIDC URL the frontend should send users to in order to log in. This is typically the same
-    # as the backend URL, but may differ if the backend can access the OIDC server over a non-public network.
-    issuer: http://localhost:8087/realms/damap
-    # Client ID as configured in the OIDC Server:
-    clientID: damap
     # Scopes to request during login:
     scope: openid profile affiliation
     # The OIDC claim path that will hold your DAMAP roles in the access token
@@ -29,27 +21,15 @@ damap:
     # The OIDC claim that holds the users affiliations
     affiliations-claim: affiliation
     # Role name used to identify DAMAP super admins
-    # If its value is not damap-super-admin, ADMIN_ROLE constant in the
-    # DefaultProfile test profile needs to be changed accordingly
+    # If DAMAP is locally deployed and the variable is not set to damap-super-admin, ADMIN_ROLE constant in the
+    # DefaultProfile test profile needs to be changed accordingly, otherwise the tests fail
     admin-role-name: damap-super-admin
-  datasource:
-    url: ${DAMAP_DATASOURCE_URL:jdbc:postgresql://damap-db:5432/damap}
-    db-kind: ${DAMAP_DATASOURCE_DB_KIND:postgresql}
-    driver: ${DAMAP_DATASOURCE_DRIVER:org.postgresql.Driver}
-
-    username: ${DAMAP_DATASOURCE_USERNAME:damap}
-    password: ${DAMAP_DATASOURCE_PASSWORD:pw4damap}
-    dialect: ${DAMAP_DATASOURCE_DIALECT:org.hibernate.dialect.PostgreSQLDialect}
   repositories:
     # Zenodo, Open Science Framework, DRYAD, Mendeley Data
     # can also be [] for no repositories recommendation
     recommendation: ['r3d100010468', 'r3d100011137', 'r3d100000044', 'r3d100011868'] # your-recommended-repositories
-  fits-url: http://fits-service:8080/fits
-  gotenberg-url: http://gotenberg:3000
   fields:
     ethical-report-enabled: true
-
-  mock-endpoint-url: http://api-mock:80
 
   projects-service: default
   ## Elsevier Pure integration:
@@ -100,7 +80,7 @@ quarkus:
   http:
     cors:
       ~: true
-      origins: ${damap.origins}
+      origins: https://your.frontend.com
       headers: origin,content-type,accept,authorization
       access-control-max-age: 1
     # needed for the fits service. Specify how large a single file for upload may be.
@@ -108,23 +88,23 @@ quarkus:
       max-body-size: 10M
 
   oidc:
-    auth-server-url: ${damap.auth.server-url}
-    client-id: ${damap.auth.clientID}
+    auth-server-url: http://localhost:8087/realms/damap
+    client-id: damap
     token:
-      issuer: ${damap.auth.issuer}
+      issuer: http://localhost:8087/realms/damap
     roles:
       role-claim-path: ${damap.auth.user-roles-claim-path}
 
   datasource:
     jdbc:
-      url: ${damap.datasource.url}
-      driver: ${damap.datasource.driver}
-    db-kind: ${damap.datasource.db-kind}
-    username: ${damap.datasource.username}
-    password: ${damap.datasource.password}
+      url: jdbc:postgresql://damap-db:5432/damap
+      driver: org.postgresql.Driver
+    db-kind: postgresql
+    username: damap
+    password: pw4damap
 
   hibernate-orm:
-    dialect: ${damap.datasource.dialect}
+    dialect: org.hibernate.dialect.PostgreSQLDialect
     database:
       generation: none
     sql-load-script: no-file
@@ -145,7 +125,7 @@ quarkus:
 
   swagger-ui:
     always-include: true # set to false if swagger-ui should only be available in dev mode
-    oauth-client-id: ${damap.auth.clientID}
+    oauth-client-id: ${quarkus.oidc.client-id}
 
   rest-client:
     elsevier-pure:
@@ -153,10 +133,10 @@ quarkus:
 
 rest:
   elsevier-pure/mp-rest/url: ${damap.elsevier-pure-endpoint-url}
-  mock-projects/mp-rest/url: ${damap.mock-endpoint-url}
-  mock-persons/mp-rest/url: ${damap.mock-endpoint-url}
-  fits/mp-rest/url: ${damap.fits-url}
-  gotenberg/mp-rest/url: ${damap.gotenberg-url}
+  mock-projects/mp-rest/url: http://api-mock:80
+  mock-persons/mp-rest/url: http://api-mock:80
+  fits/mp-rest/url: http://fits-service:8080/fits
+  gotenberg/mp-rest/url: http://gotenberg:3000
   r3data:
     repositories/mp-rest/url: https://www.re3data.org/api
     repositories/mp-rest/scope: jakarta.inject.Singleton
@@ -167,26 +147,41 @@ rest:
 "%dev":
   damap:
     title: "DAMAP (Development)"
-    origins: http://localhost:4200
     auth:
-      server-url: http://localhost:8087/realms/damap
-      issuer: http://localhost:8087/realms/damap
-      clientID: damap
       scope: 'openid profile email offline_access microprofile-jwt roles personID'
       user-id-claim: personID
       user-roles-claim-path: realm_access/roles
       admin-role-name: Damap Admin
+
+  quarkus:
+    http:
+      cors:
+        origins: http://localhost:4200
+
+    oidc:
+      auth-server-url: http://localhost:8087/realms/damap
+      client-id: damap
+      token:
+        issuer: http://localhost:8087/realms/damap
+      roles:
+        role-claim-path: ${damap.auth.user-roles-claim-path}
+
+    # FOR ORACLE INSTEAD USE:
+    #      url: jdbc:oracle:thin:@localhost:8088/FREEPDB1
+    #      db-kind: oracle
     datasource:
-      url: jdbc:postgresql://localhost:8088/damap
+      jdbc:
+        url: jdbc:postgresql://localhost:8088/damap
+        driver: org.postgresql.Driver
       db-kind: postgresql
-      # FOR ORACLE INSTEAD USE:
-      #      url: jdbc:oracle:thin:@localhost:8088/FREEPDB1
-      #      db-kind: oracle
       username: damap
       password: pw4damap
-    mock-endpoint-url: http://localhost:8091
-    fits-url: http://localhost:8089/fits
-    gotenberg-url: http://localhost:3000
+
+    rest:
+      fits/mp-rest/url: http://localhost:8089/fits
+      gotenberg/mp-rest/url: http://localhost:3000
+      mock-projects/mp-rest/url: http://localhost:8091
+      mock-persons/mp-rest/url: http://localhost:8091
 
 "%test":
   damap:
@@ -210,12 +205,6 @@ rest:
     datasource:
       active: false # deactivate unnamed default datasource
       bootstrap: # the same as deactivated default datasource, but with a name, needed for CustomTenantResolver
-        jdbc:
-          url: ${damap.datasource.url}
-          driver: ${damap.datasource.driver}
-        db-kind: ${damap.datasource.db-kind}
-        username: ${damap.datasource.username}
-        password: ${damap.datasource.password}
 
     liquibase:
       bootstrap:

--- a/src/test/java/org/damap/base/TestProfiles.java
+++ b/src/test/java/org/damap/base/TestProfiles.java
@@ -24,7 +24,7 @@ public class TestProfiles {
 
     // admin role name is configured in application.yaml under damap.auth.admin-role-name
     // but @TestSecurity cannot read from the application.yaml, so it needs to be hardcoded here
-    public static final String ADMIN_ROLE = "damap-super-admin";
+    public static final String ADMIN_ROLE = "DAMAP ADMIN";
 
     /** Makes sure that only the Mock services are used and not real systems like PURE */
     @Override

--- a/src/test/java/org/damap/base/rest/ConfigResourceTest.java
+++ b/src/test/java/org/damap/base/rest/ConfigResourceTest.java
@@ -15,11 +15,11 @@ import org.junit.jupiter.api.Test;
 @TestProfile(TestProfiles.DefaultProfile.class)
 class ConfigResourceTest {
 
-  @ConfigProperty(name = "quarkus.oidc.auth-server-url")
-  String serverUrl;
+  @ConfigProperty(name = "quarkus.oidc.issuer")
+  String issuer;
 
   @Test
   void testGetConfigEndpoint() {
-    given().when().get().then().statusCode(200).body("issuer", is(serverUrl));
+    given().when().get().then().statusCode(200).body("issuer", is(issuer));
   }
 }

--- a/src/test/java/org/damap/base/rest/ConfigResourceTest.java
+++ b/src/test/java/org/damap/base/rest/ConfigResourceTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 @TestProfile(TestProfiles.DefaultProfile.class)
 class ConfigResourceTest {
 
-  @ConfigProperty(name = "quarkus.oidc.issuer")
+  @ConfigProperty(name = "quarkus.oidc.token.issuer")
   String issuer;
 
   @Test

--- a/src/test/java/org/damap/base/rest/ConfigResourceTest.java
+++ b/src/test/java/org/damap/base/rest/ConfigResourceTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 @TestProfile(TestProfiles.DefaultProfile.class)
 class ConfigResourceTest {
 
-  @ConfigProperty(name = "damap.auth.server-url")
+  @ConfigProperty(name = "quarkus.oidc.auth-server-url")
   String serverUrl;
 
   @Test

--- a/src/test/java/org/damap/base/rest/InternalStorageTranslationResourceTest.java
+++ b/src/test/java/org/damap/base/rest/InternalStorageTranslationResourceTest.java
@@ -22,8 +22,6 @@ import org.junit.jupiter.api.Test;
 @TestProfile(TestProfiles.DefaultProfile.class)
 class InternalStorageTranslationResourceTest {
 
-  final String test = "damap-super-admin";
-
   @Inject TestDOFactory testDOFactory;
 
   // Authorization tests
@@ -157,7 +155,7 @@ class InternalStorageTranslationResourceTest {
   }
 
   @Test
-  @TestSecurity(user = "adminJwt", roles = test)
+  @TestSecurity(user = "adminJwt", roles = ADMIN_ROLE)
   void testCreateEndpointValidData_Created() {
     Long id = testDOFactory.prepareInternalStorageOption();
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
Refactoring, Config

#### What does this PR do?
Removes the need for admins to go into application.yaml for configuration - this is moved to an .env file with detailed environment variables.

#### Breaking changes
Breaks older deployments due to the massiv changes in the application.yaml.

#### Code review focus
Did I transition everything correctly? What should i do with `person-services`, since its a list of configs.

### Update [2026-01-30T19:08Z]
- [ ] Update helm chart

Tests:
- [x] Test on Docker with Oracle/PostgreSQL
- [ ] Test on vanilla K8s
- [ ] Test on Openshift
- [ ] Test on Openshift & Arisnet Red Hat Keycloak
