### PR TITLE
pure: allow instance use of Pure API and add improvements

### DIFF
--- a/src/main/java/org/damap/base/integration/pure/FileBasedPureAPI.java
+++ b/src/main/java/org/damap/base/integration/pure/FileBasedPureAPI.java
@@ -6,6 +6,8 @@ import jakarta.enterprise.inject.Typed;
 import jakarta.inject.Inject;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.extern.jbosslog.JBossLog;
 import org.damap.base.rest.config.domain.TenantConfigResolver;
 import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
@@ -20,17 +22,22 @@ import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
 @RegisterClientHeaders(PureAuthenticationHeaderFactory.class)
 class FileBasedPureAPI implements PureAPI {
 
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
   @Inject TenantConfigResolver tenantConfigResolver;
 
   @Override
   public PureAPIPaginatedProjectsResponse listAllProjects(Long size, Long offset) {
-    ObjectMapper mapper = new ObjectMapper();
-    try (InputStream in =
-        tenantConfigResolver.getTenantAwareConfig().elsevierPureProjectsFile().openStream()) {
-      return mapper.readValue(in, PureAPIPaginatedProjectsResponse.class);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
+    return singlePage(readAllProjectsFromFile());
+  }
+
+  @Override
+  public PureAPIPaginatedProjectsResponse searchProjects(String q, Long size, Long offset) {
+    List<PureAPIProject> all = readAllProjectsFromFile();
+    if (q != null && !q.isBlank()) {
+      all = all.stream().filter(p -> p != null && p.titleContains(q)).toList();
     }
+    return singlePage(all);
   }
 
   @Override
@@ -43,10 +50,9 @@ class FileBasedPureAPI implements PureAPI {
 
   @Override
   public PureAPIPaginatedPersonsResponse listAllPersons(Long size, Long offset) {
-    ObjectMapper mapper = new ObjectMapper();
     try (InputStream in =
         tenantConfigResolver.getTenantAwareConfig().elsevierPurePersonsFile().openStream()) {
-      return mapper.readValue(in, PureAPIPaginatedPersonsResponse.class);
+      return objectMapper.readValue(in, PureAPIPaginatedPersonsResponse.class);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -55,5 +61,32 @@ class FileBasedPureAPI implements PureAPI {
   @Override
   public PureAPIPerson getPerson(String uuid) {
     return listAllPersons().stream().filter(p -> p.getUuid().equals(uuid)).findFirst().orElse(null);
+  }
+
+  private List<PureAPIProject> readAllProjectsFromFile() {
+    try (InputStream in =
+        tenantConfigResolver.getTenantAwareConfig().elsevierPureProjectsFile().openStream()) {
+      PureAPIPaginatedProjectsResponse resp =
+          objectMapper.readValue(in, PureAPIPaginatedProjectsResponse.class);
+      if (resp == null || resp.getItems() == null) {
+        return List.of();
+      }
+      return resp.getItems();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private PureAPIPaginatedProjectsResponse singlePage(List<PureAPIProject> all) {
+    PureAPIPaginatedProjectsResponse page = new PureAPIPaginatedProjectsResponse();
+    page.setCount(all.size());
+
+    PureAPIPageInformation info = new PureAPIPageInformation();
+    info.setOffset(0);
+    info.setSize(all.size());
+    page.setPageInformation(info);
+
+    page.setItems(new ArrayList<>(all));
+    return page;
   }
 }

--- a/src/main/java/org/damap/base/integration/pure/HTTPBasedPureAPI.java
+++ b/src/main/java/org/damap/base/integration/pure/HTTPBasedPureAPI.java
@@ -39,6 +39,36 @@ interface HTTPBasedPureAPI extends PureAPI {
       @QueryParam("size") Long size, @QueryParam("offset") Long offset);
 
   /**
+   * Search projects via {@code POST /projects/search}.
+   *
+   * @param query the search query body.
+   * @return the response containing the matching projects on that page.
+   */
+  @POST
+  @Path("/projects/search")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Fallback(fallbackMethod = "searchProjectsPostFallback", skipOn = DamapApiException.class)
+  PureAPIPaginatedProjectsResponse searchProjectsPost(PureAPIProjectsQuery query);
+
+  /**
+   * Search projects using pagination. Delegates to {@link #searchProjectsPost} with a {@link
+   * PureAPIProjectsQuery} body.
+   *
+   * @param q query string, passed to Pure API {@code searchString} parameter
+   * @param size the size of the page.
+   * @param offset the offset to start at.
+   * @return the response containing the projects on that page.
+   */
+  @Override
+  default PureAPIPaginatedProjectsResponse searchProjects(String q, Long size, Long offset) {
+    PureAPIProjectsQuery body = new PureAPIProjectsQuery();
+    body.setSearchString(q);
+    if (size != null) body.setSize(size.intValue());
+    if (offset != null) body.setOffset(offset.intValue());
+    return searchProjectsPost(body);
+  }
+
+  /**
    * Retrieve a project with a specific ID.
    *
    * @param uuid the ID of the project.
@@ -104,6 +134,10 @@ interface HTTPBasedPureAPI extends PureAPI {
   }
 
   default PureAPIPaginatedProjectsResponse listAllProjectsFallback(Long size, Long offset) {
+    throw fallback();
+  }
+
+  default PureAPIPaginatedProjectsResponse searchProjectsPostFallback(PureAPIProjectsQuery query) {
     throw fallback();
   }
 

--- a/src/main/java/org/damap/base/integration/pure/PureAPI.java
+++ b/src/main/java/org/damap/base/integration/pure/PureAPI.java
@@ -44,6 +44,16 @@ interface PureAPI {
   PureAPIPerson getPerson(String uuid);
 
   /**
+   * Search projects using pagination.
+   *
+   * @param q query string, passed to Pure API {@code q} parameter
+   * @param size the size of the page.
+   * @param offset the offset to start at.
+   * @return the response containing the projects on that page.
+   */
+  PureAPIPaginatedProjectsResponse searchProjects(String q, Long size, Long offset);
+
+  /**
    * Retrieve all projects, sending multiple queries to the Pure API.
    *
    * @return a list of all projects in the Pure database.
@@ -51,10 +61,38 @@ interface PureAPI {
   default List<PureAPIProject> listAllProjects() {
     List<PureAPIProject> items = new ArrayList<>();
     long offset = 0;
-    long pageSize = 10;
+    long pageSize = 100;
     boolean finished = false;
     while (!finished) {
       PureAPIPaginatedProjectsResponse projects = listAllProjects(pageSize, offset);
+      if (projects == null || projects.items == null || projects.pageInformation == null) {
+        break;
+      }
+      items.addAll(projects.items);
+      offset = projects.pageInformation.offset + projects.pageInformation.size;
+      if (projects.count <= offset) {
+        finished = true;
+      }
+    }
+    return items;
+  }
+
+  /**
+   * Search projects, sending multiple queries to the Pure API.
+   *
+   * @param q query string, passed to Pure API {@code q} parameter
+   * @return a list of matching projects
+   */
+  default List<PureAPIProject> searchAllProjects(String q) {
+    List<PureAPIProject> items = new ArrayList<>();
+    long offset = 0;
+    long pageSize = 100;
+    boolean finished = false;
+    while (!finished) {
+      PureAPIPaginatedProjectsResponse projects = searchProjects(q, pageSize, offset);
+      if (projects == null || projects.items == null || projects.pageInformation == null) {
+        break;
+      }
       items.addAll(projects.items);
       offset = projects.pageInformation.offset + projects.pageInformation.size;
       if (projects.count <= offset) {
@@ -72,10 +110,13 @@ interface PureAPI {
   default List<PureAPIPerson> listAllPersons() {
     List<PureAPIPerson> items = new ArrayList<>();
     long offset = 0;
-    long pageSize = 10;
+    long pageSize = 100;
     boolean finished = false;
     while (!finished) {
       PureAPIPaginatedPersonsResponse persons = listAllPersons(pageSize, offset);
+      if (persons == null || persons.items == null || persons.pageInformation == null) {
+        break;
+      }
       items.addAll(persons.items);
       offset = persons.pageInformation.offset + persons.pageInformation.size;
       if (persons.count <= offset) {

--- a/src/main/java/org/damap/base/integration/pure/PureAPIProject.java
+++ b/src/main/java/org/damap/base/integration/pure/PureAPIProject.java
@@ -51,9 +51,6 @@ class PureAPIProject {
 
   ProjectDO toProjectDO(String descriptionClassificationURI) {
     ProjectDO result = new ProjectDO();
-    if (pureId != null) {
-      result.setId(pureId);
-    }
     if (uuid != null) {
       result.setUniversityId(uuid);
     }

--- a/src/main/java/org/damap/base/integration/pure/PureAPIProjectsQuery.java
+++ b/src/main/java/org/damap/base/integration/pure/PureAPIProjectsQuery.java
@@ -1,0 +1,19 @@
+package org.damap.base.integration.pure;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+/**
+ * Request body for the {@code POST /projects/search} Pure API endpoint.
+ *
+ * @see <a href="https://api.elsevierpure.com/ws/api/rapidoc.html#post-/projects/search">Elsevier
+ *     Pure API doc</a>
+ */
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+class PureAPIProjectsQuery {
+  @JsonProperty Integer size;
+  @JsonProperty Integer offset;
+  @JsonProperty String searchString;
+}

--- a/src/main/java/org/damap/base/integration/pure/PureCacheKeyGenerator.java
+++ b/src/main/java/org/damap/base/integration/pure/PureCacheKeyGenerator.java
@@ -1,0 +1,37 @@
+package org.damap.base.integration.pure;
+
+import io.quarkus.cache.CacheKeyGenerator;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import org.damap.base.security.SecurityService;
+
+/**
+ * Cache key generator for Pure API caches. Prepends tenant ID to every key so cache entries are
+ * isolated per tenant. For {@code getRecommended}, also includes the user ID since results are
+ * filtered per user.
+ *
+ * <p>Caching is applied at the {@link PureProjectService} level rather than on the {@link PureAPI}
+ * interface because Quarkus REST client proxies do not support CDI interceptors on default methods.
+ */
+@ApplicationScoped
+class PureCacheKeyGenerator implements CacheKeyGenerator {
+
+  @Inject SecurityService securityService;
+
+  @Override
+  public Object generate(Method method, Object... methodParams) {
+    List<Object> key = new ArrayList<>();
+    String affiliation = securityService.getAffiliation();
+    key.add(affiliation != null ? affiliation : "single-tenant");
+    if ("getRecommended".equals(method.getName())) {
+      key.add(securityService.getUserId());
+    }
+    for (Object param : methodParams) {
+      key.add(param);
+    }
+    return key;
+  }
+}

--- a/src/main/java/org/damap/base/integration/pure/PurePersonService.java
+++ b/src/main/java/org/damap/base/integration/pure/PurePersonService.java
@@ -1,5 +1,6 @@
 package org.damap.base.integration.pure;
 
+import io.quarkus.cache.CacheResult;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.stream.Collectors;
@@ -24,6 +25,7 @@ public class PurePersonService implements PersonService {
 
   /** {@inheritDoc} */
   @Override
+  @CacheResult(cacheName = "pure-read-person", keyGenerator = PureCacheKeyGenerator.class)
   public ContributorDO read(String id) {
     PureAPIPerson person = pureAPI.getPerson(id);
     if (person == null) {
@@ -34,6 +36,7 @@ public class PurePersonService implements PersonService {
 
   /** {@inheritDoc} */
   @Override
+  @CacheResult(cacheName = "pure-search-persons", keyGenerator = PureCacheKeyGenerator.class)
   public ResultList<ContributorDO> search(Search search) {
     ResultList<ContributorDO> result = new ResultList<>();
     result.setSearch(search);

--- a/src/main/java/org/damap/base/integration/pure/PureProjectService.java
+++ b/src/main/java/org/damap/base/integration/pure/PureProjectService.java
@@ -1,5 +1,6 @@
 package org.damap.base.integration.pure;
 
+import io.quarkus.cache.CacheResult;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.*;
@@ -56,7 +57,9 @@ public class PureProjectService implements ProjectServiceProvider {
         contributor.setLastName(external.name.lastName);
       }
       convertContributorRoles(participantAssociation, contributor);
-      contributor.setUniversityId(external.externalPerson.uuid);
+      if (external.externalPerson != null) {
+        contributor.setUniversityId(external.externalPerson.uuid);
+      }
       return contributor;
     }
     return null;
@@ -108,11 +111,21 @@ public class PureProjectService implements ProjectServiceProvider {
   }
 
   @Override
+  // the cache key generator function uses the method name - take care when renaming
+  @CacheResult(cacheName = "pure-recommended", keyGenerator = PureCacheKeyGenerator.class)
   public ResultList<ProjectDO> getRecommended(Search search) {
     ResultList<ProjectDO> res = new ResultList<>();
     res.setSearch(search);
-    res.setItems(
+
+    String userId = securityService.getUserId();
+    if (userId == null) {
+      res.setItems(new ArrayList<>());
+      return res;
+    }
+
+    List<ProjectDO> matchingProjects =
         pureAPI.listAllProjects().stream()
+            .filter(project -> project.participants != null)
             .filter(
                 project ->
                     project.participants.stream()
@@ -122,20 +135,28 @@ public class PureProjectService implements ProjectServiceProvider {
                             participant ->
                                 participant instanceof PureAPIInternalParticipantAssociation)
                         .anyMatch(
-                            participant ->
-                                ((PureAPIInternalParticipantAssociation) participant)
-                                    .person.uuid.equals(securityService.getUserId())))
+                            participant -> {
+                              PureAPIInternalParticipantAssociation internal =
+                                  (PureAPIInternalParticipantAssociation) participant;
+                              return internal.person != null
+                                  && internal.person.uuid != null
+                                  && internal.person.uuid.equals(userId);
+                            }))
             .map(
                 project ->
                     project.toProjectDO(
                         tenantConfigResolver
                             .getTenantAwareConfig()
                             .elsevierPureDescriptionClassification()))
-            .toList());
+            .toList();
+
+    res.setItems(matchingProjects);
+
     return res;
   }
 
   @Override
+  @CacheResult(cacheName = "pure-read-project", keyGenerator = PureCacheKeyGenerator.class)
   public ProjectDO read(String id) {
     PureAPIProject project = pureAPI.getProject(id);
     if (project == null || project.participants == null) {
@@ -146,12 +167,13 @@ public class PureProjectService implements ProjectServiceProvider {
   }
 
   @Override
+  @CacheResult(cacheName = "pure-search-projects", keyGenerator = PureCacheKeyGenerator.class)
   public ResultList<ProjectDO> search(Search query) {
+    System.out.println("muahhh");
     ResultList<ProjectDO> res = new ResultList<>();
     res.setSearch(query);
     res.setItems(
-        pureAPI.listAllProjects().stream()
-            .filter(project -> project.titleContains(query.getQuery()))
+        pureAPI.searchAllProjects(query.getQuery()).stream()
             .map(
                 project ->
                     project.toProjectDO(

--- a/src/main/java/org/damap/base/rest/PersonServiceBroker.java
+++ b/src/main/java/org/damap/base/rest/PersonServiceBroker.java
@@ -37,6 +37,10 @@ public class PersonServiceBroker {
                   service.getClass().getCanonicalName().split("_ClientProxy")[0];
 
               if (configClassName.equals(serviceClassName)) {
+                log.info(
+                    String.format(
+                        "PersonService registered: queryValue='%s', className='%s', instance='%s'",
+                        serviceConfig.getQueryValue(), configClassName, serviceClassName));
                 personServices.put(serviceConfig.getQueryValue(), service);
                 found = true;
                 break;
@@ -74,6 +78,15 @@ public class PersonServiceBroker {
     PersonService searchService = personServices.get(searchServiceType);
     if (searchService == null && !personServices.isEmpty()) {
       searchService = personServices.entrySet().iterator().next().getValue();
+      log.warn(
+          String.format(
+              "PersonService '%s' not found, using fallback: %s",
+              searchServiceType, searchService.getClass().getCanonicalName()));
+    } else if (searchService != null) {
+      log.info(
+          String.format(
+              "PersonService selected: queryParam='%s', service=%s",
+              searchServiceType, searchService.getClass().getCanonicalName()));
     }
 
     return searchService;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -121,6 +121,16 @@ quarkus:
         initial-capacity: 100
         maximum-size: 1000
         expire-after-write: 12H
+      "pure-recommended":
+        expire-after-write: 1H
+      "pure-search-projects":
+        expire-after-write: 1H
+      "pure-read-project":
+        expire-after-write: 1H
+      "pure-read-person":
+        expire-after-write: 1H
+      "pure-search-persons":
+        expire-after-write: 1H
 
   liquibase:
     migrate-at-start: true

--- a/src/test/java/org/damap/base/integration/pure/PureProjectsWireMockIntegrationTest.java
+++ b/src/test/java/org/damap/base/integration/pure/PureProjectsWireMockIntegrationTest.java
@@ -164,6 +164,32 @@ public class PureProjectsWireMockIntegrationTest {
   }
 
   @Test
+  public void testHTTPSearchProjectsEndpoint() {
+    wireMockServer.stubFor(
+        post(urlPathEqualTo("/projects/search"))
+            .withHeader("api-key", equalTo("test-api-key"))
+            .withHeader("Content-Type", containing("application/json"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(createMockProjectsResponse())));
+
+    PureAPIPaginatedProjectsResponse response = pureAPI.searchProjects("Test", 10L, 0L);
+
+    assertNotNull(response, "Response should not be null");
+    assertNotNull(response.getItems(), "Items should not be null");
+    assertEquals(2, response.getItems().size(), "Should have 2 projects from search results");
+
+    wireMockServer.verify(
+        postRequestedFor(urlPathEqualTo("/projects/search"))
+            .withHeader("api-key", equalTo("test-api-key"))
+            .withRequestBody(matchingJsonPath("$.searchString", equalTo("Test")))
+            .withRequestBody(matchingJsonPath("$.size", equalTo("10")))
+            .withRequestBody(matchingJsonPath("$.offset", equalTo("0"))));
+  }
+
+  @Test
   public void testProjectsAPIKeyAuthenticationFailure() {
     wireMockServer.stubFor(
         get(urlPathEqualTo("/projects"))


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/damap-org/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
I made the Pure and related classes that the instance uses public. With that, the TUG instance can use
Pure from core and extend it e.g. my own project service that builds on the core one.

#### What does this PR do?
<!-- Changes introduced by this PR - what happened before, what happens now -->

#### Breaking changes
<!-- Whether this PR contains breaking changes and which -->

#### Code review focus
`ProjectDO` has two different fields: `id` - database primary key and `universityId` (e.g. Pure UUID). When mapping from Pure we must only set `universityId` from Pure’s UUID. We must not set `id` from Pure’s ID: that would make Hibernate treat the entity as an existing one and trigger `EntityExistsException` when saving a DMP that links to this project. The rest of the codebase already uses `universityId` for lookups (e.g. `DmpService`, project read by `universityId`), so this is the correct field for the Pure project reference.

Also handled the pagination - instead of loading all projects in one go; add null checks and error handling.

#### Dependencies
<!-- If this PR depends on or requires other/additional (frontend) changes, please list them here -->

### Checks
<!-- Adjust list as necessary -->
<!-- In case of DB changes make sure that names do not exceed 30 chars and that audit tables have been created/updated and do not contain FKs on entities. -->
- [ ] Tested with Oracle/PostgreSQL
- [ ] Export updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-<!-- insert issue number -->
