### PR TITLE
Multitenancy: Sanitize affiliation strings

### DIFF
--- a/src/main/java/org/damap/base/security/SecurityService.java
+++ b/src/main/java/org/damap/base/security/SecurityService.java
@@ -125,7 +125,7 @@ public class SecurityService {
                         throw new UnauthorizedException(
                             "Affiliation is expected to include an @: " + aff);
                       }
-                      return aff.split("@")[1];
+                      return aff.split("@")[1].replace(".", "_");
                     })
                 .distinct()
                 .toList();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/damap-org/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
Potential Bugfix

#### What does this PR do?
Instead of reading the affiliation as is, we replace "." with "_" to avoid potential future problems with db naming.

