### PR TITLE
Helm: point DAMAP default tags to release candidate

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -34,5 +34,3 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: Initial release of DAMAP Helm chart
-    - kind: note
-      description: This chart version is intended for testing and is not recommended for production use

--- a/helm/templates/00_multitenancy_db_init.yaml
+++ b/helm/templates/00_multitenancy_db_init.yaml
@@ -28,6 +28,12 @@ spec:
                 secretKeyRef:
                   name: damap
                   key: db_password
+          resources:
+            requests:
+              cpu: 25m
+              memory: 128Mi
+            limits:
+              memory: 256Mi
           command:
             - sh
             - -c

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -14,7 +14,7 @@ customBuild:
     repo: https://github.com/damap-org/damap-frontend
 
 damap:
-  backendVersion: next # TODO: Pin version when the rc is released
+  backendVersion: 5.0.0-rc1
   customDomain: false
   dbName: damap
   # NOTE: When db_password is empty, Helm will try to reuse the existing Secret if present.
@@ -23,7 +23,7 @@ damap:
   # This mismatch can cause DB/service failures. Use a fixed password or pre-created Secret to ensure stability.
   dbPassword: "damap_pass" # Empty defaults to auto-generate.
   dbUser: damap
-  frontendVersion: next # TODO: Pin version when the rc is released
+  frontendVersion: 5.0.0-rc1
   # Host folder to persist data for demo / small scale deployments.
   # NOTE: Do not use for production!
   hostFolder: /tmp/damap


### PR DESCRIPTION
Since the release candidate is now available to pull, we can safely reference it in the default values and avoid using `next`, which is unpredictable and can cause failures.

Also, apply requests and limits for the tenant Job, OpenShift requires it.