### PR TITLE
Multitenancy: Fix bootstrap db not being configured

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -201,6 +201,12 @@ rest:
     datasource:
       active: false # deactivate unnamed default datasource
       bootstrap: # the same as deactivated default datasource, but with a name, needed for CustomTenantResolver
+        jdbc:
+          url: ${quarkus.datasource.jdbc.url}
+          driver: ${quarkus.datasource.jdbc.driver}
+        db-kind: ${quarkus.datasource.db-kind}
+        username: ${quarkus.datasource.username}
+        password: ${quarkus.datasource.password}
 
     liquibase:
       bootstrap:


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/damap-org/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
Bugfix

#### What does this PR do?
Reintroduces the missing configuration for the multitenancy bootstrap db, which essentially just copies the settings from the default db thats used in normal mode without multitenancy. Got mistakenly removed in https://github.com/damap-org/damap-backend/pull/459
