### PR TITLE
Helm(fix): add missing environment variables for multitenancy

### DIFF
--- a/helm/templates/03_damap.yaml
+++ b/helm/templates/03_damap.yaml
@@ -136,7 +136,7 @@ spec:
             {{- if .Values.damap.multitenancy.enabled }}
             - name: QUARKUS_DATASOURCE_BOOTSTRAP_DB_KIND
               value: postgresql
-            - name: QUARKUS_DATASOURCE_BOOTSTRAP_DRIVER
+            - name: QUARKUS_DATASOURCE_BOOTSTRAP_JDBC_DRIVER
               value: org.postgresql.Driver
             - name: QUARKUS_DATASOURCE_BOOTSTRAP_JDBC_URL
               value: "jdbc:postgresql://damap-db:5432/{{ .Values.damap.dbName }}"

--- a/helm/templates/03_damap.yaml
+++ b/helm/templates/03_damap.yaml
@@ -131,12 +131,29 @@ spec:
                   key: dbPassword
 
             {{- /*
-            Quarkus Profile for multitenancy
+            Quarkus config for multitenancy
             */}}
             {{- if .Values.damap.multitenancy.enabled }}
+            - name: QUARKUS_DATASOURCE_BOOTSTRAP_DB_KIND
+              value: postgresql
+            - name: QUARKUS_DATASOURCE_BOOTSTRAP_DRIVER
+              value: org.postgresql.Driver
+            - name: QUARKUS_DATASOURCE_BOOTSTRAP_JDBC_URL
+              value: "jdbc:postgresql://damap-db:5432/{{ .Values.damap.dbName }}"
+            - name: QUARKUS_DATASOURCE_BOOTSTRAP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: damap
+                  key: dbPassword
+            - name: QUARKUS_DATASOURCE_BOOTSTRAP_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: damap
+                  key: dbUsername
             - name: QUARKUS_PROFILE
               value: multitenant
             {{- end }}
+
             {{- /*
             Authentication configuration.
             */}}


### PR DESCRIPTION
When enabling multitenancy, the backend crashes on startup with:
Datasource 'bootstrap' is not configured

This happens because the bootstrap datasource was defined but did not read the values from the default datasource environment variables, so Quarkus could not connect to the main DB to initialize tenant databases.