### PR TITLE
Helm(fix): update multitenancy DB credentials & backend environment variables

### DIFF
--- a/docker/example.env
+++ b/docker/example.env
@@ -83,8 +83,8 @@ QUARKUS_HIBERNATE_ORM_DIALECT=org.hibernate.dialect.PostgreSQLDialect
 ## REST
 ## =====================
 
-QUARKUS_REST_FITS_MP_REST_URL=http://fits-service:8080/fits
-QUARKUS_GOTENBERG_MP_REST_URL=http://gotenberg:3000
+REST_FITS_MP_REST_URL=http://fits-service:8080/fits
+REST_GOTENBERG_MP_REST_URL=http://gotenberg:3000
 
 
 ## =====================

--- a/helm/templates/00_multitenancy.yaml
+++ b/helm/templates/00_multitenancy.yaml
@@ -19,8 +19,8 @@ stringData:
               url: jdbc:postgresql://damap-db:5432/{{ $tenant }}
               driver: org.postgresql.Driver
             db-kind: postgresql
-            username: {{ $.Values.damap.dbUser }}
-            password: {{ $.Values.damap.dbPassword }}
+            username: ${QUARKUS_DATASOURCE_USERNAME}
+            password: ${QUARKUS_DATASOURCE_PASSWORD}
           {{- end }}
         liquibase:
           {{- range $tenant := .Values.damap.multitenancy.tenants }}

--- a/helm/templates/03_damap.yaml
+++ b/helm/templates/03_damap.yaml
@@ -92,6 +92,8 @@ spec:
           ports:
             - containerPort: 9000
           env:
+            - name: QUARKUS_HTTP_CORS_ORIGINS
+              value: "{{ .Values.damap.protocol }}://{{ .Values.damap.hostname }}"
             - name: QUARKUS_HTTP_PORT
               value: "9000"
 
@@ -111,8 +113,6 @@ spec:
 
             - name: DAMAP_ENV
               value: "{{ if eq .Values.debug true }}DEV{{ else }}PROD{{ end }}"
-            - name: DAMAP_ORIGINS
-              value: "{{ .Values.damap.protocol }}://{{ .Values.damap.hostname }}"
             
             {{- /*
             Database configuration
@@ -213,7 +213,7 @@ spec:
             */}}
             - name: DAMAP_FITS_URL
               value: ""
-            - name: DAMAP_GOTENBERG_URL
+            - name: REST_GOTENBERG_MP_REST_URL
               value: "http://localhost:3000"
 
             {{- /*


### PR DESCRIPTION
This PR bring the helm pre-release into a stable state:

Deployments will now correctly use Quarkus-managed DB credentials for multitenancy configuration.
Backend services are aligned with updated environment variable naming conventions.