### PR TITLE
Config: Fix small copy-paste errors in example.env

### DIFF
--- a/docker/example.env
+++ b/docker/example.env
@@ -18,17 +18,18 @@ QUARKUS_HTTP_CORS_ORIGINS=http://localhost:8085
 #   - default
 #   - elsevier-pure
 DAMAP_PROJECTS_SERVICE=default
-# Text shown in the frontend to allow users to switch between person services
-DAMAP_PERSON_SERVICE_DISPLAY_TEXT=University
+# Text shown  in the frontend to allow users to switch between person services
+DAMAP_PERSON_SERVICES_DISPLAY_TEXT=University
 # Sets which person service is used
 # Allowed values:
 #   - UNIVERSITY
 #   - PURE
-DAMAP_PERSON_SERVICE_QUERY_VALUE=UNIVERSITY
+DAMAP_PERSON_SERVICES_QUERY_VALUE=UNIVERSITY
 # Which java class is to be used as person service
 # Set to org.damap.base.integration.pure.PurePersonService for PURE
 # Or to your custom class, if you do use a custom integration
-DAMAP_PERSON_SERVICE_CLASS_NAME=org.damap.base.integration.mock.MockUniversityPersonServiceImpl
+DAMAP_PERSON_SERVICES_CLASS_NAME=org.damap.base.integration.mock.MockUniversityPersonServiceImpl
+
 ## =====================
 ## Authentication
 ## =====================
@@ -41,7 +42,7 @@ QUARKUS_OIDC_TOKEN_ISSUER=http://localhost:8087/realms/damap
 # Client ID as configured in the OIDC Server
 QUARKUS_OIDC_CLIENT_ID=damap
 # Scopes to request during login
-DAMAP_AUTH_SCOPES="openid profile email offline_access microprofile-jwt roles personID"
+DAMAP_AUTH_SCOPE="openid profile email offline_access microprofile-jwt roles personID"
 # The OIDC claim path that will hold your DAMAP roles in the access token
 # Also accepts paths, e.g. "realm_access/roles"
 DAMAP_AUTH_USER_ROLES_CLAIM_PATH=realm_access/roles
@@ -91,6 +92,7 @@ REST_GOTENBERG_MP_REST_URL=http://gotenberg:3000
 ## Fields
 ## =====================
 
+# Enables input field for short ethical report description
 DAMAP_FIELDS_ETHICAL_REPORT_ENABLED=true
 
 ## =====================
@@ -101,21 +103,21 @@ DAMAP_FIELDS_ETHICAL_REPORT_ENABLED=true
 # /dk/atira/pure, but are otherwise specific to the institutional setup in Pure.
 
 # The project description field DAMAP should use:
-ELSEVIER_PURE_DESCRIPTION_CLASSIFICATION: /dk/atira/pure/projectdescription
+DAMAP_ELSEVIER_PURE_DESCRIPTION_CLASSIFICATION=/dk/atira/pure/projectdescription
 # How Pure project contributor classifications map to DAMAP:
-ELSEVIER_PURE_CONTRIBUTOR_ROLE_CLASSIFICATIONS_DK_ATIRA_PURE_MEMBER: PROJECT_MEMBER
+DAMAP_ELSEVIER_PURE_CONTRIBUTOR_ROLE_CLASSIFICATIONS='{"/dk/atira/pure/member":"PROJECT_MEMBER"}'
 # Which Pure classification should be read as the project lead:
-ELSEVIER_PURE_PROJECT_LEAD_CLASSIFICATIONS: /dk/atira/pure/projectlead
+DAMAP_ELSEVIER_PURE_PROJECT_LEAD_ROLE_CLASSIFICATION=/dk/atira/pure/projectlead
 # Configures if data should be fetched over http or from local files - should always be http for PROD:
 # Allowed values:
 #   - http
 #   - file
-ELSEVIER_PURE_BACKEND: http
+DAMAP_ELSEVIER_PURE_BACKEND=http
 # URL to fetch data from, only relevant when ELSEVIER_PURE_BACKEND is set to http
-ELSEVIER_PURE_ENDPOINT_URL: "https://your-pure-instance.elsevierpure.com/ws/api"
+DAMAP_ELSEVIER_PURE_ENDPOINT_URL="https://your-pure-instance.elsevierpure.com/ws/api"
 # API key used to authenticate over the PURE API, only relevant when ELSEVIER_PURE_BACKEND is set to http
-ELSEVIER_PURE_API_KEY: "your API key here"
+DAMAP_ELSEVIER_PURE_API_KEY="your API key here"
 # location of projects file, only relevant when ELSEVIER_PURE_BACKEND is set to file
-ELSEVIER_PURE_PROJECTS_FILE: "file:///path/to/projects.json"
+DAMAP_ELSEVIER_PURE_PROJECTS_FILE="file:///path/to/projects.json"
 # location of persons file, only relevant when ELSEVIER_PURE_BACKEND is set to file
-ELSEVIER_PURE_PERSONS_FILE: "file:///path/to/persons.json"
+DAMAP_ELSEVIER_PURE_PERSONS_FILE="file:///path/to/persons.json"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -24,10 +24,6 @@ damap:
     # If DAMAP is locally deployed ADMIN_ROLE constant in the DefaultProfile test profile needs to be
     # the same as here, otherwise the tests fail
     admin-role-name: Damap Admin
-  repositories:
-    # Zenodo, Open Science Framework, DRYAD, Mendeley Data
-    # can also be [] for no repositories recommendation
-    recommendation: ['r3d100010468', 'r3d100011137', 'r3d100000044', 'r3d100011868'] # your-recommended-repositories
   fields:
     ethical-report-enabled: true
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/damap-org/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
Bugfix

#### What does this PR do?
Fixes copy-paste errors in the example.env file and adds a small amount of documentation to it.

#### Code review focus
The helm chart already uses the correct env variables, but I couldnt find the `DAMAP_PERSON_SERVICES_DISPLAY_TEXT`, `DAMAP_PERSON_SERVICES_QUERY_VALUE` and `DAMAP_PERSON_SERVICES_CLASS_NAME` variables in the helm chart. Can you check if the helm chart uses the correct variables? (I renamed them from SERVICE to SERVICES)
