### PR TITLE
Helm(fix): update outdated custom domain value in damap ingress & fix custom build refs

### DIFF
--- a/helm/templates/03_damap.yaml
+++ b/helm/templates/03_damap.yaml
@@ -77,7 +77,7 @@ spec:
         - name: damap-backend
 
           {{- if and .Values.openshift (ne .Values.customBuild.backend.name "") }}
-          image: "{{ .Values.customBuild.backend.name }}:{{ .Values.customBuild.backend.ref }}"
+          image: "image-registry.openshift-image-registry.svc:5000/{{ .Release.Namespace }}/{{ .Values.customBuild.backend.name }}:{{ .Values.customBuild.backend.ref }}"
           {{- else }}
           image: "ghcr.io/damap-org/damap-backend:{{ .Values.damap.backendVersion }}"
           {{- end }}
@@ -345,7 +345,7 @@ spec:
       containers:
         - name: damap-frontend
           {{- if and .Values.openshift (ne .Values.customBuild.frontend.name "") }}
-          image: "{{ .Values.customBuild.frontend.name }}:{{ .Values.customBuild.frontend.ref }}"
+          image: "image-registry.openshift-image-registry.svc:5000/{{ .Release.Namespace }}/{{ .Values.customBuild.frontend.name }}:{{ .Values.customBuild.frontend.ref }}"
           {{- else }}
           image: "ghcr.io/damap-org/damap-frontend:{{ .Values.damap.frontendVersion }}"
           {{- end }}

--- a/helm/templates/05_damap_ingress.yaml
+++ b/helm/templates/05_damap_ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.openshift (not .Values.damap.custom_domain) }}
+{{- if and .Values.openshift (not .Values.damap.customDomain) }}
 {{- /*
 OpenShift default domain (Route)
 */}}


### PR DESCRIPTION
This fix renames the outdated `custom_domain` value to `customDomain`.

This affects OpenShift deployments using a custom domain; the chart rendered the default OpenShift `Route` resources instead of the expected `Ingress` resources using the OpenShift `ingressClass` (fetched from the `values.yaml`).

The custom build was also fixed, referencing the correct image registry from OpenShift.
Note: If running the chart with kustomize (as in our case), remember to specify the namespace explicitly in the charts section ( {{ .Release.namespace }} may not be correctly populated in the custom build section)