### PR TITLE
Maintenance: External API usage in export protected with catch-try

### DIFF
--- a/src/main/java/org/damap/base/conversion/AbstractTemplateExportScienceEuropeComponents.java
+++ b/src/main/java/org/damap/base/conversion/AbstractTemplateExportScienceEuropeComponents.java
@@ -105,13 +105,15 @@ public abstract class AbstractTemplateExportScienceEuropeComponents
     // add funding program to funding item variables
     ProjectDO projectCRIS = null;
     if (project.getUniversityId() != null) {
-      try { // This try catch is there to prevent export crashing when an external dependency is down
+      try { // This try catch is there to prevent export crashing when an external dependency is
+        // down
         projectCRIS = projectService.read(project.getUniversityId());
       } catch (Exception e) {
         ProjectDO fallback = new ProjectDO();
         FundingDO dummyFunding = new FundingDO();
-        dummyFunding.setFundingProgram("Project service was not available. This should be the funding program fetched" +
-                " from the project service. To get this information, please try to export at a later date.");
+        dummyFunding.setFundingProgram(
+            "Project service was not available. This should be the funding program fetched"
+                + " from the project service. To get this information, please try to export at a later date.");
         fallback.setFunding(dummyFunding);
         projectCRIS = fallback;
         log.error("Could not reach Project Service for funding details", e);
@@ -763,7 +765,8 @@ public abstract class AbstractTemplateExportScienceEuropeComponents
           repo -> {
             String description;
             String url = "";
-            try { // This try catch is there to prevent export crashing when an external dependency is down
+            try { // This try catch is there to prevent export crashing when an external dependency
+              // is down
               description = repositoriesService.getDescription(repo.getRepositoryId());
               url = repositoriesService.getRepositoryURL(repo.getRepositoryId());
             } catch (Exception e) {
@@ -1382,7 +1385,8 @@ public abstract class AbstractTemplateExportScienceEuropeComponents
         docVar.add(joinWithComma(repositoryTitles));
 
         Set<EIdentifierType> pids = new HashSet<>();
-        try { // This try catch is there to prevent export crashing when an external dependency is down
+        try { // This try catch is there to prevent export crashing when an external dependency is
+          // down
           for (Repository repository : repositories) {
             pids.addAll(repositoriesService.getPidSystems(repository.getRepositoryId()));
           }

--- a/src/main/java/org/damap/base/conversion/AbstractTemplateExportScienceEuropeComponents.java
+++ b/src/main/java/org/damap/base/conversion/AbstractTemplateExportScienceEuropeComponents.java
@@ -12,6 +12,7 @@ import org.apache.poi.xwpf.usermodel.*;
 import org.damap.base.domain.*;
 import org.damap.base.enums.*;
 import org.damap.base.rest.dmp.domain.ContributorDO;
+import org.damap.base.rest.dmp.domain.FundingDO;
 import org.damap.base.rest.dmp.domain.ProjectDO;
 import org.damap.base.rest.dmp.mapper.ContributorDOMapper;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTVMerge;
@@ -104,9 +105,15 @@ public abstract class AbstractTemplateExportScienceEuropeComponents
     // add funding program to funding item variables
     ProjectDO projectCRIS = null;
     if (project.getUniversityId() != null) {
-      try {
+      try { // This try catch is there to prevent export crashing when an external dependency is down
         projectCRIS = projectService.read(project.getUniversityId());
       } catch (Exception e) {
+        ProjectDO fallback = new ProjectDO();
+        FundingDO dummyFunding = new FundingDO();
+        dummyFunding.setFundingProgram("Project service was not available. This should be the funding program fetched" +
+                " from the project service. To get this information, please try to export at a later date.");
+        fallback.setFunding(dummyFunding);
+        projectCRIS = fallback;
         log.error("Could not reach Project Service for funding details", e);
       }
     }
@@ -756,7 +763,7 @@ public abstract class AbstractTemplateExportScienceEuropeComponents
           repo -> {
             String description;
             String url = "";
-            try {
+            try { // This try catch is there to prevent export crashing when an external dependency is down
               description = repositoriesService.getDescription(repo.getRepositoryId());
               url = repositoriesService.getRepositoryURL(repo.getRepositoryId());
             } catch (Exception e) {
@@ -1375,9 +1382,14 @@ public abstract class AbstractTemplateExportScienceEuropeComponents
         docVar.add(joinWithComma(repositoryTitles));
 
         Set<EIdentifierType> pids = new HashSet<>();
-        for (Repository repository : repositories) {
-          pids.addAll(repositoriesService.getPidSystems(repository.getRepositoryId()));
+        try { // This try catch is there to prevent export crashing when an external dependency is down
+          for (Repository repository : repositories) {
+            pids.addAll(repositoriesService.getPidSystems(repository.getRepositoryId()));
+          }
+        } catch (Exception e) {
+          log.error("Could not reach repository service for PidSystems information.");
         }
+
         docVar.add(joinWithComma(pids.stream().map(EIdentifierType::getType).toList()));
 
         // suppress license information for closed datasets

--- a/src/main/java/org/damap/base/conversion/AbstractTemplateExportScienceEuropeComponents.java
+++ b/src/main/java/org/damap/base/conversion/AbstractTemplateExportScienceEuropeComponents.java
@@ -103,8 +103,13 @@ public abstract class AbstractTemplateExportScienceEuropeComponents
 
     // add funding program to funding item variables
     ProjectDO projectCRIS = null;
-    if (project.getUniversityId() != null)
-      projectCRIS = projectService.read(project.getUniversityId());
+    if (project.getUniversityId() != null) {
+      try {
+        projectCRIS = projectService.read(project.getUniversityId());
+      } catch (Exception e) {
+        log.error("Could not reach Project Service for funding details", e);
+      }
+    }
 
     titlePageFunding(project, projectCRIS);
 
@@ -747,13 +752,24 @@ public abstract class AbstractTemplateExportScienceEuropeComponents
     }
 
     if (!repositories.isEmpty()) {
-
       repositories.forEach(
-          repo ->
-              repoTexts.add(
-                  repositoriesService.getDescription(repo.getRepositoryId())
-                      + " "
-                      + repositoriesService.getRepositoryURL(repo.getRepositoryId())));
+          repo -> {
+            String description;
+            String url = "";
+            try {
+              description = repositoriesService.getDescription(repo.getRepositoryId());
+              url = repositoriesService.getRepositoryURL(repo.getRepositoryId());
+            } catch (Exception e) {
+              log.error(
+                  "Failed to fetch repository info from external API for ID: "
+                      + repo.getRepositoryId(),
+                  e);
+              description =
+                  "re3data was not available. This should be the description fetched from re3data. "
+                      + "To get this information, please try to export at a later date.";
+            }
+            repoTexts.add(description + (url.isEmpty() ? "" : " " + url));
+          });
 
       repoInformation = String.join("; ", repoTexts);
     }

--- a/src/main/java/org/damap/base/conversion/AbstractTemplateExportSetup.java
+++ b/src/main/java/org/damap/base/conversion/AbstractTemplateExportSetup.java
@@ -81,11 +81,11 @@ public abstract class AbstractTemplateExportSetup extends AbstractTemplateExport
             log.warn("Project Leader is null for project ID: " + dmp.getProjectUniversityId());
           }
         }
-      } catch (Exception e) {
+      } catch (Exception e) { // This try catch is there to prevent export crashing when an external dependency is down
         log.error("Project API not functioning", e);
         ContributorDO fallbackLeader = new ContributorDO();
         fallbackLeader.setFirstName("Project Leader");
-        fallbackLeader.setLastName("(Information currently unavailable from Project Service)");
+        fallbackLeader.setLastName("(Information currently unavailable from Project Service, try again at a later date)");
         fallbackLeader.setRoles(new HashSet<>(Set.of(EContributorRole.PROJECT_LEADER)));
         projectCoordinators = List.of(fallbackLeader);
       }

--- a/src/main/java/org/damap/base/conversion/AbstractTemplateExportSetup.java
+++ b/src/main/java/org/damap/base/conversion/AbstractTemplateExportSetup.java
@@ -81,11 +81,15 @@ public abstract class AbstractTemplateExportSetup extends AbstractTemplateExport
             log.warn("Project Leader is null for project ID: " + dmp.getProjectUniversityId());
           }
         }
-      } catch (Exception e) { // This try catch is there to prevent export crashing when an external dependency is down
+      } catch (
+          Exception
+              e) { // This try catch is there to prevent export crashing when an external dependency
+        // is down
         log.error("Project API not functioning", e);
         ContributorDO fallbackLeader = new ContributorDO();
         fallbackLeader.setFirstName("Project Leader");
-        fallbackLeader.setLastName("(Information currently unavailable from Project Service, try again at a later date)");
+        fallbackLeader.setLastName(
+            "(Information currently unavailable from Project Service, try again at a later date)");
         fallbackLeader.setRoles(new HashSet<>(Set.of(EContributorRole.PROJECT_LEADER)));
         projectCoordinators = List.of(fallbackLeader);
       }

--- a/src/main/java/org/damap/base/conversion/AbstractTemplateExportSetup.java
+++ b/src/main/java/org/damap/base/conversion/AbstractTemplateExportSetup.java
@@ -83,6 +83,11 @@ public abstract class AbstractTemplateExportSetup extends AbstractTemplateExport
         }
       } catch (Exception e) {
         log.error("Project API not functioning", e);
+        ContributorDO fallbackLeader = new ContributorDO();
+        fallbackLeader.setFirstName("Project Leader");
+        fallbackLeader.setLastName("(Information currently unavailable from Project Service)");
+        fallbackLeader.setRoles(new HashSet<>(Set.of(EContributorRole.PROJECT_LEADER)));
+        projectCoordinators = List.of(fallbackLeader);
       }
     }
   }

--- a/src/main/java/org/damap/base/rest/dmp/service/DmpService.java
+++ b/src/main/java/org/damap/base/rest/dmp/service/DmpService.java
@@ -251,7 +251,6 @@ public class DmpService {
 
     }
 
-
     if (universityProject != null && universityProject.getAcronym() != null) {
       return universityProject.getAcronym();
     }

--- a/src/main/java/org/damap/base/rest/dmp/service/DmpService.java
+++ b/src/main/java/org/damap/base/rest/dmp/service/DmpService.java
@@ -244,8 +244,13 @@ public class DmpService {
     }
 
     String universityId = dmp.getProject().getUniversityId();
-    ProjectDO universityProject =
-        (universityId != null) ? projectServiceBroker.read(universityId) : null;
+    ProjectDO universityProject = new ProjectDO();
+    try { // This try catch is there to prevent export crashing when an external dependency is down
+      universityProject = (universityId != null) ? projectServiceBroker.read(universityId) : null;
+    } catch (Exception e) {
+
+    }
+
 
     if (universityProject != null && universityProject.getAcronym() != null) {
       return universityProject.getAcronym();


### PR DESCRIPTION
## Description
Maintenance

#### What does this PR do?
This PR adds error handling and fallback values to the document export process. Previously, if external APIs (like the Project Service or re3data) were unreachable, the export would fail entirely. Now, it catches the exceptions, logs the error, and inserts placeholder text so the user still gets their document.

Specific changes:
  * Wrapped the `projectService.read()` call in a try-catch so the title page generation survives a Project Service failure.
  * Wrapped `repositoriesService` calls (fetching repo descriptions and URLs) in a try-catch. If the re3data API fails, it outputs a fallback message into the document explaining that re3data was unavailable.
  * Added a fallback `ContributorDO` for the project coordinator if the Project API throws an exception. The exported document will now show "Project Leader (Information currently unavailable from Project Service)" instead of leaving it blank or crashing.

closes GH-470