### PR TITLE
Multitenancy: Make no affiliation claim throw a 401

### DIFF
--- a/src/main/java/org/damap/base/security/SecurityService.java
+++ b/src/main/java/org/damap/base/security/SecurityService.java
@@ -133,6 +133,10 @@ public class SecurityService {
       return null;
     }
 
+    if (oidcPrincipal.getClaims().getClaimValue(affiliationsClaim) == null) {
+      throw new UnauthorizedException("Affiliation is required");
+    }
+
     // affiliations come from the eduPersonScopedAffiliation attribute - in EduID they are
     // structured like role@institution
     // EduGain does not have this convention - currently we just throw an error if the affiliation


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/damap-org/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
Refactoring

#### What does this PR do?
Instead of just failing with a nullpointer exception when ffiliation is missing, we now throw a 401 error to make it more verbose.
