### PR TITLE
Pipeline: Add manual github packages release pipeline

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -31,14 +31,35 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check if base version exists
+        run: |
+          REPO="${{ env.REGISTRY }}/${{ github.repository }}"
+          BASE_TAG="${{ github.event.inputs.tag }}"
+
+          echo "Checking if $REPO:$BASE_TAG exists..."
+
+          if docker pull "$REPO:$BASE_TAG" > /dev/null 2>&1; then
+            echo "❌ Tag $BASE_TAG already exists. Bump the version."
+            exit 1
+          else
+            echo "✅ Tag does not exist, continuing."
+          fi
+
+      - name: Compute full tag
+        run: |
+          HASH=$(git rev-parse --short=7 HEAD)
+          FULL_TAG="${{ github.event.inputs.tag }}_${HASH}"
+          echo "FULL_TAG=$FULL_TAG" >> $GITHUB_ENV
+          echo "Using tag: $FULL_TAG"
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}
-          # git tag: v1.2.3, output: 1.2.3
+          # git tag: v1.2.3, output: 1.2.3_<hash>
           tags: |
-            type=raw,value=${{ github.event.inputs.tag }}
+            type=raw,value=${{ env.FULL_TAG }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -1,0 +1,49 @@
+# This workflow can be used to manually release a docker-image with a tag to use it for testing
+# It's just a temporary cheap solution and should be replaced with a proper workflow in the future
+name: release-dev
+
+env:
+  REGISTRY: ghcr.io
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag of the package"
+        required: true
+        default: "my-default-dev-tag"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  container-build-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}
+          # git tag: v1.2.3, output: 1.2.3
+          tags: |
+            type=raw,value=${{ github.event.inputs.tag }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/damap-org/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
Feature

#### What does this PR do?
Adds a pipeline to create a tag for the current commit and releases an image with the tag. Manually run only and meant to make testing on kubernetes easier (since only tags can be pulled). Should be replaced with a real workflow later, but for now it will do. 
