### PR TITLE
Add endpoint for fetching active languages

### DIFF
--- a/src/main/java/org/damap/base/repo/TranslationRepo.java
+++ b/src/main/java/org/damap/base/repo/TranslationRepo.java
@@ -7,7 +7,6 @@ import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.Optional;
 import org.damap.base.domain.Translation;
-import org.damap.base.rest.translation.domain.LanguageSummary;
 
 /** TranslationRepo class. */
 @ApplicationScoped
@@ -61,21 +60,18 @@ public class TranslationRepo implements PanacheRepository<Translation> {
   }
 
   /**
-   * findAllLanguageSummaries.
+   * findActiveLanguages.
    *
-   * <p>Returns a {@link LanguageSummary} for each distinct language code. A language is considered
-   * active if any translation row for that language is active.
+   * <p>Returns all distinct language codes that have at least one active translation row.
    *
-   * @return a {@link java.util.List} of language summaries ordered by language code
+   * @return a {@link java.util.List} of distinct active language code strings
    */
-  public List<LanguageSummary> findAllLanguageSummaries() {
+  public List<String> findActiveLanguages() {
     return getEntityManager()
         .createQuery(
-            "SELECT new org.damap.base.rest.translation.domain.LanguageSummary("
-                + "t.language, CASE WHEN MAX(CASE WHEN t.active = TRUE THEN 1 ELSE 0 END) = 1"
-                + " THEN TRUE ELSE FALSE END) "
-                + "FROM Translation t GROUP BY t.language ORDER BY t.language",
-            LanguageSummary.class)
+            "SELECT DISTINCT t.language FROM Translation t WHERE t.active = TRUE"
+                + " ORDER BY t.language",
+            String.class)
         .getResultList();
   }
 

--- a/src/main/java/org/damap/base/repo/TranslationRepo.java
+++ b/src/main/java/org/damap/base/repo/TranslationRepo.java
@@ -7,6 +7,7 @@ import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.Optional;
 import org.damap.base.domain.Translation;
+import org.damap.base.rest.translation.domain.LanguageSummary;
 
 /** TranslationRepo class. */
 @ApplicationScoped
@@ -56,6 +57,25 @@ public class TranslationRepo implements PanacheRepository<Translation> {
     return getEntityManager()
         .createQuery(
             "SELECT DISTINCT t.language FROM Translation t ORDER BY t.language", String.class)
+        .getResultList();
+  }
+
+  /**
+   * findAllLanguageSummaries.
+   *
+   * <p>Returns a {@link LanguageSummary} for each distinct language code. A language is considered
+   * active if any translation row for that language is active.
+   *
+   * @return a {@link java.util.List} of language summaries ordered by language code
+   */
+  public List<LanguageSummary> findAllLanguageSummaries() {
+    return getEntityManager()
+        .createQuery(
+            "SELECT new org.damap.base.rest.translation.domain.LanguageSummary("
+                + "t.language, CASE WHEN MAX(CASE WHEN t.active = TRUE THEN 1 ELSE 0 END) = 1"
+                + " THEN TRUE ELSE FALSE END) "
+                + "FROM Translation t GROUP BY t.language ORDER BY t.language",
+            LanguageSummary.class)
         .getResultList();
   }
 

--- a/src/main/java/org/damap/base/rest/TranslationResource.java
+++ b/src/main/java/org/damap/base/rest/TranslationResource.java
@@ -10,6 +10,7 @@ import jakarta.ws.rs.core.MediaType;
 import java.util.List;
 import lombok.extern.jbosslog.JBossLog;
 import org.damap.base.domain.Translation;
+import org.damap.base.rest.translation.domain.LanguageSummary;
 import org.damap.base.rest.translation.service.TranslationService;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 
@@ -29,6 +30,18 @@ public class TranslationResource {
   @GET
   public List<String> getAllLanguages() {
     return translationService.getAllLanguages();
+  }
+
+  @GET()
+  @Path("/active")
+  public List<String> getActiveLanguages() {
+    return translationService.getActiveLanguages();
+  }
+
+  @GET
+  @Path("/details")
+  public List<LanguageSummary> getAllLanguageDetails() {
+    return translationService.getAllLanguageSummaries();
   }
 
   @GET

--- a/src/main/java/org/damap/base/rest/TranslationResource.java
+++ b/src/main/java/org/damap/base/rest/TranslationResource.java
@@ -32,7 +32,7 @@ public class TranslationResource {
     return translationService.getAllLanguages();
   }
 
-  @GET()
+  @GET
   @Path("/active")
   public List<String> getActiveLanguages() {
     return translationService.getActiveLanguages();

--- a/src/main/java/org/damap/base/rest/translation/domain/LanguageSummary.java
+++ b/src/main/java/org/damap/base/rest/translation/domain/LanguageSummary.java
@@ -1,0 +1,4 @@
+package org.damap.base.rest.translation.domain;
+
+/** Per-language activation summary used by the admin UI. */
+public record LanguageSummary(String language, Boolean active) {}

--- a/src/main/java/org/damap/base/rest/translation/service/TranslationService.java
+++ b/src/main/java/org/damap/base/rest/translation/service/TranslationService.java
@@ -10,6 +10,7 @@ import lombok.extern.jbosslog.JBossLog;
 import org.damap.base.domain.Translation;
 import org.damap.base.repo.TranslationRepo;
 import org.damap.base.rest.TranslationResource.PatchTranslationRequest;
+import org.damap.base.rest.translation.domain.LanguageSummary;
 
 /** TranslationService class. */
 @ApplicationScoped
@@ -62,6 +63,27 @@ public class TranslationService {
   public List<String> getAllLanguages() {
     log.infov("Getting all languages");
     return translationRepo.findAllLanguages();
+  }
+
+  /**
+   * getActiveLanguages.
+   *
+   * @return a {@link java.util.List} of language codes
+   */
+  public List<String> getActiveLanguages() {
+    log.infov("Getting active languages");
+    return translationRepo.findActiveLanguages();
+  }
+
+  /**
+   * getAllLanguageSummaries.
+   *
+   * @return a {@link java.util.List} of {@link LanguageSummary} for every language code, including
+   *     whether the language is active
+   */
+  public List<LanguageSummary> getAllLanguageSummaries() {
+    log.infov("Getting all language summaries");
+    return translationRepo.findAllLanguageSummaries();
   }
 
   /**

--- a/src/main/java/org/damap/base/rest/translation/service/TranslationService.java
+++ b/src/main/java/org/damap/base/rest/translation/service/TranslationService.java
@@ -98,8 +98,7 @@ public class TranslationService {
    * @param language a {@link java.lang.String} language code
    * @param active a {@link java.lang.Boolean} activation flag
    * @return a {@link java.util.List} of Translation objects related to the language code
-   * @throws {@link jakarta.ws.rs.BadRequestException} if trying to deactivate the last active
-   *     language
+   * @throws jakarta.ws.rs.BadRequestException if trying to deactivate the last active language
    */
   @Transactional
   public List<Translation> activateLanguage(String language, Boolean active) {

--- a/src/main/java/org/damap/base/rest/translation/service/TranslationService.java
+++ b/src/main/java/org/damap/base/rest/translation/service/TranslationService.java
@@ -4,7 +4,10 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.jbosslog.JBossLog;
 import org.damap.base.domain.Translation;
@@ -83,7 +86,10 @@ public class TranslationService {
    */
   public List<LanguageSummary> getAllLanguageSummaries() {
     log.infov("Getting all language summaries");
-    return translationRepo.findAllLanguageSummaries();
+    Set<String> activeLanguages = new HashSet<>(translationRepo.findActiveLanguages());
+    return translationRepo.findAllLanguages().stream()
+        .map(language -> new LanguageSummary(language, activeLanguages.contains(language)))
+        .collect(Collectors.toList());
   }
 
   /**
@@ -92,12 +98,21 @@ public class TranslationService {
    * @param language a {@link java.lang.String} language code
    * @param active a {@link java.lang.Boolean} activation flag
    * @return a {@link java.util.List} of Translation objects related to the language code
+   * @throws {@link jakarta.ws.rs.BadRequestException} if trying to deactivate the last active
+   *     language
    */
   @Transactional
   public List<Translation> activateLanguage(String language, Boolean active) {
     List<Translation> translations = translationRepo.findByLanguage(language);
     if (translations.isEmpty()) {
       throw new NotFoundException("No translations found for language: " + language);
+    }
+
+    if (!active) {
+      List<String> activeLanguages = translationRepo.findActiveLanguages();
+      if (activeLanguages.size() <= 1 && activeLanguages.contains(language)) {
+        throw new BadRequestException("Cannot deactivate the last active language");
+      }
     }
 
     log.infov("Setting language active state: {0} -> {1}", language, active);
@@ -153,9 +168,6 @@ public class TranslationService {
    *
    * <p>WARNING: This is a destructive operation. All translations for the given language will be
    * permanently removed from the database.
-   *
-   * <p>Deleting the English ("en") language is not allowed and will throw a {@link
-   * jakarta.ws.rs.BadRequestException}.
    *
    * @param language a {@link java.lang.String} language code
    * @throws jakarta.ws.rs.BadRequestException if the language is "en"

--- a/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.7.0_10.yaml
+++ b/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.7.0_10.yaml
@@ -1,0 +1,281 @@
+databaseChangeLog:
+  - changeSet:
+      id: 34
+      author: Vlad Dancea
+      comment: Insert en translations for language activation toggle and irreversible delete warning
+      changes:
+        - insert:
+            tableName: translation
+            columns:
+              - column:
+                  name: translation_key
+                  value: admin.appTranslations.activateLanguage
+              - column:
+                  name: language
+                  value: en
+              - column:
+                  name: default_value
+                  value: Activate language
+              - column:
+                  name: active
+                  valueBoolean: true
+              - column:
+                  name: version
+                  valueNumeric: 0
+        - insert:
+            tableName: translation
+            columns:
+              - column:
+                  name: translation_key
+                  value: admin.appTranslations.deactivateLanguage
+              - column:
+                  name: language
+                  value: en
+              - column:
+                  name: default_value
+                  value: Deactivate language
+              - column:
+                  name: active
+                  valueBoolean: true
+              - column:
+                  name: version
+                  valueNumeric: 0
+        - insert:
+            tableName: translation
+            columns:
+              - column:
+                  name: translation_key
+                  value: admin.appTranslations.removeLanguageWarningIrreversible
+              - column:
+                  name: language
+                  value: en
+              - column:
+                  name: default_value
+                  value: "WARNING: Removing this language will permanently delete ALL of its translations. This action cannot be undone."
+              - column:
+                  name: active
+                  valueBoolean: true
+              - column:
+                  name: version
+                  valueNumeric: 0
+        - delete:
+            tableName: translation
+            where: translation_key = 'admin.appTranslations.removeLanguageWarning'
+        - insert:
+            tableName: translation
+            columns:
+              - column:
+                  name: translation_key
+                  value: http.success.translations.language.activate
+              - column:
+                  name: language
+                  value: en
+              - column:
+                  name: default_value
+                  value: Language activated successfully.
+              - column:
+                  name: active
+                  valueBoolean: true
+              - column:
+                  name: version
+                  valueNumeric: 0
+        - insert:
+            tableName: translation
+            columns:
+              - column:
+                  name: translation_key
+                  value: http.success.translations.language.deactivate
+              - column:
+                  name: language
+                  value: en
+              - column:
+                  name: default_value
+                  value: Language deactivated successfully.
+              - column:
+                  name: active
+                  valueBoolean: true
+              - column:
+                  name: version
+                  valueNumeric: 0
+        - insert:
+            tableName: translation
+            columns:
+              - column:
+                  name: translation_key
+                  value: http.error.translations.language.activate
+              - column:
+                  name: language
+                  value: en
+              - column:
+                  name: default_value
+                  value: Failed to activate the language.
+              - column:
+                  name: active
+                  valueBoolean: true
+              - column:
+                  name: version
+                  valueNumeric: 0
+        - insert:
+            tableName: translation
+            columns:
+              - column:
+                  name: translation_key
+                  value: http.error.translations.language.deactivate
+              - column:
+                  name: language
+                  value: en
+              - column:
+                  name: default_value
+                  value: Failed to deactivate the language.
+              - column:
+                  name: active
+                  valueBoolean: true
+              - column:
+                  name: version
+                  valueNumeric: 0
+        - insert:
+            tableName: translation
+            columns:
+              - column:
+                  name: translation_key
+                  value: admin.appTranslations.deactivateLanguageDisabledLastActive
+              - column:
+                  name: language
+                  value: en
+              - column:
+                  name: default_value
+                  value: At least one language must remain active.
+              - column:
+                  name: active
+                  valueBoolean: true
+              - column:
+                  name: version
+                  valueNumeric: 0
+        - insert:
+            tableName: translation
+            columns:
+              - column:
+                  name: translation_key
+                  value: admin.appTranslations.removeLanguageDisabledEnglish
+              - column:
+                  name: language
+                  value: en
+              - column:
+                  name: default_value
+                  value: The English language is the default and cannot be removed.
+              - column:
+                  name: active
+                  valueBoolean: true
+              - column:
+                  name: version
+                  valueNumeric: 0
+        - insert:
+            tableName: translation
+            columns:
+              - column:
+                  name: translation_key
+                  value: admin.appTranslations.keyLabel
+              - column:
+                  name: language
+                  value: en
+              - column:
+                  name: default_value
+                  value: Key
+              - column:
+                  name: active
+                  valueBoolean: true
+              - column:
+                  name: version
+                  valueNumeric: 0
+        - insert:
+            tableName: translation
+            columns:
+              - column:
+                  name: translation_key
+                  value: admin.appTranslations.defaultValueLabel
+              - column:
+                  name: language
+                  value: en
+              - column:
+                  name: default_value
+                  value: Default value
+              - column:
+                  name: active
+                  valueBoolean: true
+              - column:
+                  name: version
+                  valueNumeric: 0
+        - insert:
+            tableName: translation
+            columns:
+              - column:
+                  name: translation_key
+                  value: admin.appTranslations.revertToDefault
+              - column:
+                  name: language
+                  value: en
+              - column:
+                  name: default_value
+                  value: Revert to default
+              - column:
+                  name: active
+                  valueBoolean: true
+              - column:
+                  name: version
+                  valueNumeric: 0
+
+      rollback:
+        - delete:
+            tableName: translation
+            where: translation_key = 'admin.appTranslations.activateLanguage'
+        - delete:
+            tableName: translation
+            where: translation_key = 'admin.appTranslations.deactivateLanguage'
+        - delete:
+            tableName: translation
+            where: translation_key = 'admin.appTranslations.removeLanguageWarningIrreversible'
+        - insert:
+            tableName: translation
+            columns:
+              - column:
+                  name: translation_key
+                  value: admin.appTranslations.removeLanguageWarning
+              - column:
+                  name: language
+                  value: en
+              - column:
+                  name: default_value
+                  value: "WARNING: Removing this language will permanently delete ALL custom translations for this language. This action cannot be undone."
+              - column:
+                  name: active
+                  valueBoolean: true
+              - column:
+                  name: version
+                  valueNumeric: 0
+        - delete:
+            tableName: translation
+            where: translation_key = 'http.success.translations.language.activate'
+        - delete:
+            tableName: translation
+            where: translation_key = 'http.success.translations.language.deactivate'
+        - delete:
+            tableName: translation
+            where: translation_key = 'http.error.translations.language.activate'
+        - delete:
+            tableName: translation
+            where: translation_key = 'http.error.translations.language.deactivate'
+        - delete:
+            tableName: translation
+            where: translation_key = 'admin.appTranslations.deactivateLanguageDisabledLastActive'
+        - delete:
+            tableName: translation
+            where: translation_key = 'The English language is the default and cannot be removed.'
+        - delete:
+            tableName: translation
+            where: translation_key = 'admin.appTranslations.keyLabel'
+        - delete:
+            tableName: translation
+            where: translation_key = 'admin.appTranslations.defaultValueLabel'
+        - delete:
+            tableName: translation
+            where: translation_key = 'admin.appTranslations.revertToDefault'

--- a/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.x.yaml
+++ b/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.x.yaml
@@ -47,3 +47,5 @@ databaseChangeLog:
       file: org/damap/base/db/changeLog-4.x/changeLog-4.7.0_8.yaml
   - include:
       file: org/damap/base/db/changeLog-4.x/changeLog-4.7.0_9.yaml
+  - include:
+      file: org/damap/base/db/changeLog-4.x/changeLog-4.7.0_10.yaml


### PR DESCRIPTION
## Description

Feature

#### What does this PR do?
- add endpoint-to-database flow for fetching only activated languages
- add more validation to language deletion and de/activation

#### Dependencies
Depends on [Frontend PR 542](https://github.com/damap-org/damap-frontend/pull/542)
