### PR TITLE
dev: add multitenancy users to keycloak instance and local multitenancy markdown guide

### DIFF
--- a/DEV_MULTITENANCY.md
+++ b/DEV_MULTITENANCY.md
@@ -1,0 +1,99 @@
+# Local Multitenancy Setup
+
+## 1. Copy Tenant Configuration
+
+Copy the tenant configuration file from `/docker` into your application resources:
+
+```bash
+cp docker/tenants.yaml src/main/resources/tenants.yaml
+```
+
+---
+
+## 2. Configure Application
+
+Update `application.yaml` (multitenant profile):
+
+```yaml
+"%multitenant":
+  config:
+    locations: /tenants.yaml
+```
+
+---
+
+## 3. Configure Tenant Datasources
+
+Edit `tenants.yaml` and replace the datasource section with:
+
+```yaml
+datasource:
+  tenant_1:
+    db-kind: postgresql
+    username: damap
+    password: pw4damap
+    jdbc:
+      url: jdbc:postgresql://localhost:8088/tenant_1
+
+  tenant_2:
+    db-kind: postgresql
+    username: damap
+    password: pw4damap
+    jdbc:
+      url: jdbc:postgresql://localhost:8088/tenant_2
+```
+
+---
+
+## 4. Create Tenant Databases
+
+Run inside the Postgres container:
+
+```bash
+psql -U damap -d postgres -c "CREATE DATABASE tenant_1 OWNER damap;"
+psql -U damap -d postgres -c "CREATE DATABASE tenant_2 OWNER damap;"
+```
+
+---
+
+## 5. Start the Application
+
+Start Docker (DB + Keycloak), then run:
+
+```bash
+mvn quarkus:dev -Dquarkus.profile=dev,multitenant
+```
+
+---
+
+## 6. Test Users
+
+```
+tenant_1 user:
+  username: tenant1-user
+  password: password
+
+tenant_2 user:
+  username: tenant2-user
+  password: password
+
+tenant_1 admin:
+  username: tenant_1_admin
+  password: password
+
+tenant_2 admin:
+  username: tenant_2_admin
+  password: password
+```
+
+---
+
+## Notes
+
+- Default users (`user`, `admin`) are **not associated with any tenant** and will not work.
+- Tenant resolution depends on the **affiliation claim** in the JWT.
+- If tenants are not detected, verify:
+    - `tenants.yaml` exists in `src/main/resources`
+    - `config.locations` is set to `/tenants.yaml`
+- You can create or modify test users by editing `/docker/sample-damap-realm-export.json`.  
+  After changes, restart Keycloak (or re-import the realm) to apply them.

--- a/DEV_MULTITENANCY.md
+++ b/DEV_MULTITENANCY.md
@@ -29,19 +29,23 @@ Edit `tenants.yaml` and replace the datasource section with:
 ```yaml
 datasource:
   tenant_1:
-    db-kind: postgresql
-    username: damap
-    password: pw4damap
     jdbc:
       url: jdbc:postgresql://localhost:8088/tenant_1
-
+      driver: ${quarkus.datasource.jdbc.driver}
+    db-kind: ${quarkus.datasource.db-kind}
+    username: ${quarkus.datasource.username}
+    password: ${quarkus.datasource.password}
   tenant_2:
-    db-kind: postgresql
-    username: damap
-    password: pw4damap
     jdbc:
       url: jdbc:postgresql://localhost:8088/tenant_2
+      driver: ${quarkus.datasource.jdbc.driver}
+    db-kind: ${quarkus.datasource.db-kind}
+    username: ${quarkus.datasource.username}
+    password: ${quarkus.datasource.password}
 ```
+
+You can also change tenant-specific configs by playing around with the `tenant-configs:` section. This can be useful if
+you e.g. want to configure pure services for one tenant.
 
 ---
 
@@ -71,19 +75,19 @@ mvn quarkus:dev -Dquarkus.profile=dev,multitenant
 ```
 tenant_1 user:
   username: tenant1-user
-  password: password
+  password: tenant1-user
 
 tenant_2 user:
   username: tenant2-user
-  password: password
+  password: tenant2-user
 
 tenant_1 admin:
-  username: tenant_1_admin
-  password: password
+  username: tenant1_admin
+  password: tenant1_admin
 
 tenant_2 admin:
   username: tenant_2_admin
-  password: password
+  password: tenant2_admin
 ```
 
 ---

--- a/DEV_MULTITENANCY.md
+++ b/DEV_MULTITENANCY.md
@@ -20,6 +20,8 @@ Update `application.yaml` (multitenant profile):
     locations: /tenants.yaml
 ```
 
+Take care not to commit this change after testing or use the CLI flag `Dquarkus.config.locations=classpath:tenants.yaml`.
+
 ---
 
 ## 3. Configure Tenant Datasources
@@ -74,19 +76,19 @@ mvn quarkus:dev -Dquarkus.profile=dev,multitenant
 
 ```
 tenant_1 user:
-  username: tenant1-user
-  password: tenant1-user
+  username: tenant1_user
+  password: tenant1_user
 
 tenant_2 user:
-  username: tenant2-user
-  password: tenant2-user
+  username: tenant2_user
+  password: tenant2_user
 
 tenant_1 admin:
   username: tenant1_admin
   password: tenant1_admin
 
 tenant_2 admin:
-  username: tenant_2_admin
+  username: tenant2_admin
   password: tenant2_admin
 ```
 

--- a/docker/sample-damap-realm-export.json
+++ b/docker/sample-damap-realm-export.json
@@ -2342,7 +2342,7 @@
       ]
     },
     {
-      "username": "tenant1-user",
+      "username": "tenant1_user",
       "enabled": true,
       "emailVerified": true,
       "firstName": "Tenant",
@@ -2352,7 +2352,7 @@
         "offline_access"
       ],
       "attributes": {
-        "personID": ["tenant1-user"],
+        "personID": ["tenant1_user"],
         "affiliation": [
           "member@tenant_1",
           "student@tenant_1"
@@ -2361,20 +2361,20 @@
       "credentials": [
         {
           "type": "password",
-          "value": "tenant1-user",
+          "value": "tenant1_user",
           "temporary": false
         }
       ]
     },
     {
-      "username": "tenant1-admin",
+      "username": "tenant1_admin",
       "enabled": true,
       "emailVerified": true,
       "firstName": "Tenant",
       "lastName": "One Admin",
       "email": "tenant1-admin@example.com",
       "attributes": {
-        "personID": ["tenant1-admin"],
+        "personID": ["tenant1_admin"],
         "affiliation": [
           "member@tenant_1"
         ]
@@ -2386,13 +2386,13 @@
       "credentials": [
         {
           "type": "password",
-          "value": "tenant1-admin",
+          "value": "tenant1_admin",
           "temporary": false
         }
       ]
     },
     {
-      "username": "tenant2-user",
+      "username": "tenant2_user",
       "enabled": true,
       "emailVerified": true,
       "firstName": "Tenant",
@@ -2402,7 +2402,7 @@
         "offline_access"
       ],
       "attributes": {
-        "personID": ["tenant2-user"],
+        "personID": ["tenant2_user"],
         "affiliation": [
           "member@tenant_2",
           "student@tenant_2"
@@ -2411,20 +2411,20 @@
       "credentials": [
         {
           "type": "password",
-          "value": "tenant2-user",
+          "value": "tenant2_user",
           "temporary": false
         }
       ]
     },
     {
-      "username": "tenant2-admin",
+      "username": "tenant2_admin",
       "enabled": true,
       "emailVerified": true,
       "firstName": "Tenant",
       "lastName": "Two Admin",
       "email": "tenant2-admin@example.com",
       "attributes": {
-        "personID": ["tenant2-admin"],
+        "personID": ["tenant2_admin"],
         "affiliation": [
           "member@tenant_2"
         ]
@@ -2436,7 +2436,7 @@
       "credentials": [
         {
           "type": "password",
-          "value": "tenant2-admin",
+          "value": "tenant2_admin",
           "temporary": false
         }
       ]

--- a/docker/sample-damap-realm-export.json
+++ b/docker/sample-damap-realm-export.json
@@ -939,6 +939,21 @@
             "claim.name": "personID",
             "jsonType.label": "String"
           }
+        },
+        {
+          "name": "affiliation",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "affiliation",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "affiliation",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
         }
       ]
     },
@@ -2324,6 +2339,106 @@
       "realmRoles": [
         "Damap Admin",
         "default-roles-damap"
+      ]
+    },
+    {
+      "username": "tenant1-user",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tenant",
+      "lastName": "One User",
+      "email": "tenant1-user@example.com",
+      "realmRoles": [
+        "offline_access"
+      ],
+      "attributes": {
+        "personID": ["tenant1-user"],
+        "affiliation": [
+          "member@tenant_1",
+          "student@tenant_1"
+        ]
+      },
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "username": "tenant1-admin",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tenant",
+      "lastName": "One Admin",
+      "email": "tenant1-admin@example.com",
+      "attributes": {
+        "personID": ["tenant1-admin"],
+        "affiliation": [
+          "member@tenant_1"
+        ]
+      },
+      "realmRoles": [
+        "Damap Admin",
+        "offline_access"
+      ],
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "username": "tenant2-user",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tenant",
+      "lastName": "Two User",
+      "email": "tenant2-user@example.com",
+      "realmRoles": [
+        "offline_access"
+      ],
+      "attributes": {
+        "personID": ["tenant2-user"],
+        "affiliation": [
+          "member@tenant_2",
+          "student@tenant_2"
+        ]
+      },
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "username": "tenant2-admin",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tenant",
+      "lastName": "Two Admin",
+      "email": "tenant2-admin@example.com",
+      "attributes": {
+        "personID": ["tenant2-admin"],
+        "affiliation": [
+          "member@tenant_2"
+        ]
+      },
+      "realmRoles": [
+        "offline_access",
+        "Damap Admin"
+      ],
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
       ]
     }
   ]

--- a/docker/sample-damap-realm-export.json
+++ b/docker/sample-damap-realm-export.json
@@ -2361,7 +2361,7 @@
       "credentials": [
         {
           "type": "password",
-          "value": "password",
+          "value": "tenant1-user",
           "temporary": false
         }
       ]
@@ -2386,7 +2386,7 @@
       "credentials": [
         {
           "type": "password",
-          "value": "password",
+          "value": "tenant1-admin",
           "temporary": false
         }
       ]
@@ -2411,7 +2411,7 @@
       "credentials": [
         {
           "type": "password",
-          "value": "password",
+          "value": "tenant2-user",
           "temporary": false
         }
       ]
@@ -2436,7 +2436,7 @@
       "credentials": [
         {
           "type": "password",
-          "value": "password",
+          "value": "tenant2-admin",
           "temporary": false
         }
       ]

--- a/docker/tenants.yaml
+++ b/docker/tenants.yaml
@@ -29,14 +29,14 @@ damap:
         title: Tenant 2 DAMAP Tool
         fields:
           ethical-report-enabled: false
-        project-service: disabled
+        project-service: default
         elsevier-pure-description-classification: /dk/atira/pure/projectdescription
         elsevier-pure-contributor-role-classifications:
           - pure-role-uri: /dk/atira/pure/member
             contributor-role: PROJECT_MEMBER
         elsevier-pure-project-lead-role-classification: /dk/atira/pure/projectlead
         elsevier-pure-backend: http
-        elsevier-pure-endpoint-url: "https://your-tenant2-pure-instance.elsevierpure.com/ws/api/GRAZ"
+        elsevier-pure-endpoint-url: "https://your-tenant2-pure-instance.elsevierpure.com/ws/api"
         elsevier-pure-api-key: "your API key here"
         elsevier-pure-projects-file: "file:///path/to/projects.json"
         elsevier-pure-persons-file: "file:///path/to/persons.json"
@@ -44,9 +44,9 @@ damap:
           - display-text: 'ORCID'
             query-value: 'ORCID'
             class-name: 'org.damap.base.integration.orcid.ORCIDPersonServiceImpl'
-          - display-text: 'Pure'
-            query-value: 'PURE'
-            class-name: 'org.damap.base.integration.pure.PurePersonService'
+          - display-text: 'University'
+            query-value: 'UNIVERSITY'
+            class-name: 'org.damap.base.integration.mock.MockUniversityPersonServiceImpl'
 
 "%multitenant":
   quarkus:
@@ -54,9 +54,17 @@ damap:
       tenant_1:
         jdbc:
           url: jdbc:postgresql://damap-db:5432/tenant_1
+          driver: ${quarkus.datasource.jdbc.driver}
+        db-kind: ${quarkus.datasource.db-kind}
+        username: ${quarkus.datasource.username}
+        password: ${quarkus.datasource.password}
       tenant_2:
         jdbc:
           url: jdbc:postgresql://damap-db:5432/tenant_2
+          driver: ${quarkus.datasource.jdbc.driver}
+        db-kind: ${quarkus.datasource.db-kind}
+        username: ${quarkus.datasource.username}
+        password: ${quarkus.datasource.password}
 
     liquibase:
       tenant_1:


### PR DESCRIPTION
## Description

### Type
Config

### What does this PR do?

This PR improves the local developer experience for multitenancy by providing a complete, ready-to-use setup.

It introduces:
- A new **`DEV_MULTITENANCY.md`** guide explaining how to run DAMAP locally in multitenant mode
- Configuration instructions in markdown guide
- Updates to the Keycloak realm export:
  - adds an **`affiliation` protocol mapper** so the claim is available in JWTs
  - adds **example users and admins for two tenants (`tenant_1`, `tenant_2`)**
    - including proper `affiliation` attributes for tenant resolution

The goal is to allow developers to spin up a working multitenant environment locally with minimal manual setup.

---

### Dependencies

- Relies on frontend/backend logic that uses the **`affiliation` claim** for tenant resolution
- Requires local Postgres databases (`tenant_1`, `tenant_2`) to exist (see MD guide for command)

---

### Notes

- Default users (`user`, `admin`) are intentionally not affiliated with any tenant and cannot be used in multitenant mode
- Additional test users can be added via `/docker/sample-damap-realm-export.json`