### PR TITLE
Multitenancy: Fix bug where affiliation dashes did not get replaced

### DIFF
--- a/src/main/java/org/damap/base/hibernate/CustomTenantResolver.java
+++ b/src/main/java/org/damap/base/hibernate/CustomTenantResolver.java
@@ -35,7 +35,6 @@ public class CustomTenantResolver implements TenantResolver {
     // the system
     // would throw 401 otherwise - and those users shouldnt get their information stored
     if (!securityService.doesUserHaveValidAffiliation()) {
-      System.out.println("catch!!");
       return getDefaultTenantId();
     }
     String tenantId = securityService.getAffiliation();

--- a/src/main/java/org/damap/base/security/SecurityService.java
+++ b/src/main/java/org/damap/base/security/SecurityService.java
@@ -167,7 +167,9 @@ public class SecurityService {
                         throw new UnauthorizedException(
                             "Affiliation is expected to include an @: " + aff);
                       }
-                      return aff.split("@")[1].replace(".", "_");
+                      return aff.split("@")[1]
+                          .replaceAll("[^a-zA-Z0-9_]", "_")
+                          .replaceAll("_+", "_");
                     })
                 .distinct()
                 .toList();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/damap-org/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
Bugfix

#### What does this PR do?
I assumed that affiliations would only contain dots, but apparently they also can contain dashes. I now used a regex which replaces every non alphanumerical character with an underscore and removes double underscores, if they should occur.

#### Breaking changes
Yes, potentially changes how affiliations are resolved, but it should not "break" anything except our test instance on staging.
