### PR TITLE
fix: change admin.banner.dialog.button.update value from 'edit' to 'save' (#509)

### DIFF
--- a/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.7.0_5.yaml
+++ b/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.7.0_5.yaml
@@ -1005,7 +1005,7 @@ databaseChangeLog:
                   value: en
               - column:
                   name: default_value
-                  value: Edit
+                  value: Save
               - column:
                   name: active
                   valueBoolean: true


### PR DESCRIPTION
## Description
Bugfix

#### What does this PR do?
Changed `admin.banner.dialog.button.update` value from `Edit` to `Save` in the translation changelog as per the issue requirement.

#### Breaking changes
None

#### Code review focus
Translation value change in `changeLog-4.7.0_5.yaml`

#### Dependencies
None

### Checks
- [ ] Tested with Oracle/PostgreSQL
- [ ] Export updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-509