### PR TITLE
translation: only allow for ISO 639-1 language codes for application translations and internal storage translations. remove old e_language reference table for internal storage translations, migrate "eng" to "en", "deu" to "de"

### DIFF
--- a/src/main/java/org/damap/base/rest/storage/InternalStorageTranslationValidator.java
+++ b/src/main/java/org/damap/base/rest/storage/InternalStorageTranslationValidator.java
@@ -9,6 +9,7 @@ import org.damap.base.domain.InternalStorage;
 import org.damap.base.domain.InternalStorageTranslation;
 import org.damap.base.repo.InternalStorageRepo;
 import org.damap.base.repo.InternalStorageTranslationRepo;
+import org.damap.base.rest.translation.service.LanguageCodeValidator;
 
 @UtilityClass
 @JBossLog
@@ -20,6 +21,8 @@ public class InternalStorageTranslationValidator {
       InternalStorageTranslationRepo internalStorageTranslationRepo)
       throws ClientErrorException {
     log.info("Validating internal storage translation for creation");
+
+    normalizeAndValidateLanguageCode(internalStorageTranslationDO);
 
     // Check if no translation for the same language exists
     if (internalStorageTranslationRepo.existsTranslationForStorageIdAndLanguageCode(
@@ -43,6 +46,8 @@ public class InternalStorageTranslationValidator {
       InternalStorageRepo internalStorageRepo)
       throws ClientErrorException {
     log.info("Validating internal storage translation for update");
+
+    normalizeAndValidateLanguageCode(internalStorageTranslationDO);
 
     InternalStorageTranslation internalStorageTranslation =
         internalStorageTranslationRepo.findById(Long.parseLong(id));
@@ -80,11 +85,25 @@ public class InternalStorageTranslationValidator {
           "No internal storage found for id " + internalStorageTranslationDO.getStorageId());
     }
 
-    // Check if language code is 'deu' or 'eng'
-    if (!internalStorageTranslationDO.getLanguageCode().equals("deu")
-        && !internalStorageTranslationDO.getLanguageCode().equals("eng")) {
+    normalizeAndValidateLanguageCode(internalStorageTranslationDO);
+  }
+
+  private void normalizeAndValidateLanguageCode(
+      InternalStorageTranslationDO internalStorageTranslationDO) {
+    String languageCode = internalStorageTranslationDO.getLanguageCode();
+
+    if (languageCode == null || languageCode.isBlank()) {
       throw new ClientErrorException(
-          "Language code must be 'deu' or 'eng'", Response.Status.BAD_REQUEST);
+          "Language code must not be empty", Response.Status.BAD_REQUEST);
     }
+
+    String normalizedLanguageCode = languageCode.trim().toLowerCase();
+
+    if (!LanguageCodeValidator.isValidIso6391Code(normalizedLanguageCode)) {
+      throw new ClientErrorException(
+          "Invalid ISO 639-1 language code: " + languageCode, Response.Status.BAD_REQUEST);
+    }
+
+    internalStorageTranslationDO.setLanguageCode(normalizedLanguageCode);
   }
 }

--- a/src/main/java/org/damap/base/rest/translation/service/LanguageCodeValidator.java
+++ b/src/main/java/org/damap/base/rest/translation/service/LanguageCodeValidator.java
@@ -1,0 +1,33 @@
+package org.damap.base.rest.translation.service;
+
+import java.util.Set;
+
+public final class LanguageCodeValidator {
+
+  // Language codes come from "https://gist.github.com/josantonius/b455e315bc7f790d14b136d61d9ae469"
+  private static final Set<String> ISO_639_1_CODES =
+      Set.of(
+          "aa", "ab", "ae", "af", "ak", "am", "an", "ar", "as", "av", "ay", "az", "ba", "be", "bg",
+          "bh", "bi", "bm", "bn", "bo", "br", "bs", "ca", "ce", "ch", "co", "cr", "cs", "cu", "cv",
+          "cy", "da", "de", "dv", "dz", "ee", "el", "en", "eo", "es", "et", "eu", "fa", "ff", "fi",
+          "fj", "fo", "fr", "fy", "ga", "gd", "gl", "gn", "gu", "gv", "ha", "he", "hi", "ho", "hr",
+          "ht", "hu", "hy", "hz", "ia", "id", "ie", "ig", "ii", "ik", "io", "is", "it", "iu", "ja",
+          "jv", "ka", "kg", "ki", "kj", "kk", "kl", "km", "kn", "ko", "kr", "ks", "ku", "kv", "kw",
+          "ky", "la", "lb", "lg", "li", "ln", "lo", "lt", "lu", "lv", "mg", "mh", "mi", "mk", "ml",
+          "mn", "mr", "ms", "mt", "my", "na", "nb", "nd", "ne", "ng", "nl", "nn", "no", "nr", "nv",
+          "ny", "oc", "oj", "om", "or", "os", "pa", "pi", "pl", "ps", "pt", "qu", "rm", "rn", "ro",
+          "ru", "rw", "sa", "sc", "sd", "se", "sg", "si", "sk", "sl", "sm", "sn", "so", "sq", "sr",
+          "ss", "st", "su", "sv", "sw", "ta", "te", "tg", "th", "ti", "tk", "tl", "tn", "to", "tr",
+          "ts", "tt", "tw", "ty", "ug", "uk", "ur", "uz", "ve", "vi", "vo", "wa", "wo", "xh", "yi",
+          "yo", "za", "zh", "zu");
+
+  private LanguageCodeValidator() {}
+
+  public static boolean isValidIso6391Code(String languageCode) {
+    if (languageCode == null) {
+      return false;
+    }
+
+    return ISO_639_1_CODES.contains(languageCode.trim().toLowerCase());
+  }
+}

--- a/src/main/java/org/damap/base/rest/translation/service/TranslationService.java
+++ b/src/main/java/org/damap/base/rest/translation/service/TranslationService.java
@@ -8,6 +8,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.jbosslog.JBossLog;
 import org.damap.base.domain.Translation;
@@ -38,7 +41,7 @@ public class TranslationService {
 
     List<Translation> existing = translationRepo.findByLanguage(normalizedLanguage);
     if (!existing.isEmpty()) {
-      return existing;
+      throw new WebApplicationException("Language already exists", Response.Status.CONFLICT);
     }
 
     log.infov("Creating new language: {0}", newLanguage);

--- a/src/main/java/org/damap/base/rest/translation/service/TranslationService.java
+++ b/src/main/java/org/damap/base/rest/translation/service/TranslationService.java
@@ -34,7 +34,9 @@ public class TranslationService {
    */
   @Transactional
   public List<Translation> createLanguage(String newLanguage) {
-    List<Translation> existing = translationRepo.findByLanguage(newLanguage);
+    String normalizedLanguage = normalizeAndValidateLanguage(newLanguage);
+
+    List<Translation> existing = translationRepo.findByLanguage(normalizedLanguage);
     if (!existing.isEmpty()) {
       return existing;
     }
@@ -182,5 +184,19 @@ public class TranslationService {
     if (translationRepo.deleteByLanguage(language) == 0) {
       throw new NotFoundException("No translations found for language: " + language);
     }
+  }
+
+  private String normalizeAndValidateLanguage(String language) {
+    if (language == null || language.isBlank()) {
+      throw new BadRequestException("Language code must not be empty");
+    }
+
+    String normalizedLanguage = language.trim().toLowerCase();
+
+    if (!LanguageCodeValidator.isValidIso6391Code(normalizedLanguage)) {
+      throw new BadRequestException("Invalid ISO 639-1 language code: " + language);
+    }
+
+    return normalizedLanguage;
   }
 }

--- a/src/main/java/org/damap/base/rest/translation/service/TranslationService.java
+++ b/src/main/java/org/damap/base/rest/translation/service/TranslationService.java
@@ -4,13 +4,12 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import jakarta.ws.rs.WebApplicationException;
-import jakarta.ws.rs.core.Response;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.jbosslog.JBossLog;
 import org.damap.base.domain.Translation;

--- a/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.7.0_13.yaml
+++ b/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.7.0_13.yaml
@@ -11,13 +11,7 @@ databaseChangeLog:
                       'Please select a valid ISO 639-1 language code.',
                       l.active,
                       0
-                    FROM (SELECT DISTINCT language, active FROM translation) l
-                    WHERE NOT EXISTS (
-                      SELECT 1
-                      FROM translation t
-                      WHERE t.translation_key = 'admin.appTranslations.languageCodeInvalid'
-                        AND t.language = l.language
-                    );
+                    FROM (SELECT DISTINCT language, active FROM translation) l;
 
               - sql: |
                     INSERT INTO translation (translation_key, language, default_value, active, version)
@@ -27,29 +21,17 @@ databaseChangeLog:
                       'This language already exists.',
                       l.active,
                       0
-                    FROM (SELECT DISTINCT language, active FROM translation) l
-                    WHERE NOT EXISTS (
-                      SELECT 1
-                      FROM translation t
-                      WHERE t.translation_key = 'admin.appTranslations.languageCodeAlreadyExists'
-                        AND t.language = l.language
-                    );
+                    FROM (SELECT DISTINCT language, active FROM translation) l;
 
               - sql: |
                     INSERT INTO translation (translation_key, language, default_value, active, version)
                     SELECT
                       'admin.internalStorage.translation.dialog.field.languageCodeHint',
                       l.language,
-                      'Search by language name or code, for example English or EN.',
+                      'Search by language name or code, for example "English" or "en".',
                       l.active,
                       0
-                    FROM (SELECT DISTINCT language, active FROM translation) l
-                    WHERE NOT EXISTS (
-                      SELECT 1
-                      FROM translation t
-                      WHERE t.translation_key = 'admin.internalStorage.translation.dialog.field.languageCodeHint'
-                        AND t.language = l.language
-                    );
+                    FROM (SELECT DISTINCT language, active FROM translation) l;
 
               - sql: |
                     INSERT INTO translation (translation_key, language, default_value, active, version)
@@ -59,29 +41,7 @@ databaseChangeLog:
                       'Language code is required.',
                       l.active,
                       0
-                    FROM (SELECT DISTINCT language, active FROM translation) l
-                    WHERE NOT EXISTS (
-                      SELECT 1
-                      FROM translation t
-                      WHERE t.translation_key = 'admin.internalStorage.translation.dialog.field.languageCodeRequired'
-                        AND t.language = l.language
-                    );
-
-              - sql: |
-                    INSERT INTO translation (translation_key, language, default_value, active, version)
-                    SELECT
-                      'admin.internalStorage.translation.dialog.field.languageCodePattern',
-                      l.language,
-                      'Please enter a two-letter language code.',
-                      l.active,
-                      0
-                    FROM (SELECT DISTINCT language, active FROM translation) l
-                    WHERE NOT EXISTS (
-                      SELECT 1
-                      FROM translation t
-                      WHERE t.translation_key = 'admin.internalStorage.translation.dialog.field.languageCodePattern'
-                        AND t.language = l.language
-                    );
+                    FROM (SELECT DISTINCT language, active FROM translation) l;
 
               - sql: |
                     INSERT INTO translation (translation_key, language, default_value, active, version)
@@ -91,10 +51,4 @@ databaseChangeLog:
                       'Please select a valid ISO 639-1 language code.',
                       l.active,
                       0
-                    FROM (SELECT DISTINCT language, active FROM translation) l
-                    WHERE NOT EXISTS (
-                      SELECT 1
-                      FROM translation t
-                      WHERE t.translation_key = 'admin.internalStorage.translation.dialog.field.languageCodeInvalid'
-                        AND t.language = l.language
-                    );
+                    FROM (SELECT DISTINCT language, active FROM translation) l;

--- a/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.7.0_13.yaml
+++ b/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.7.0_13.yaml
@@ -1,0 +1,100 @@
+databaseChangeLog:
+    - changeSet:
+          id: 37
+          author: Geoffrey Karnbach
+          changes:
+              - sql: |
+                    INSERT INTO translation (translation_key, language, default_value, active, version)
+                    SELECT
+                      'admin.appTranslations.languageCodeInvalid',
+                      l.language,
+                      'Please select a valid ISO 639-1 language code.',
+                      l.active,
+                      0
+                    FROM (SELECT DISTINCT language, active FROM translation) l
+                    WHERE NOT EXISTS (
+                      SELECT 1
+                      FROM translation t
+                      WHERE t.translation_key = 'admin.appTranslations.languageCodeInvalid'
+                        AND t.language = l.language
+                    );
+
+              - sql: |
+                    INSERT INTO translation (translation_key, language, default_value, active, version)
+                    SELECT
+                      'admin.appTranslations.languageCodeAlreadyExists',
+                      l.language,
+                      'This language already exists.',
+                      l.active,
+                      0
+                    FROM (SELECT DISTINCT language, active FROM translation) l
+                    WHERE NOT EXISTS (
+                      SELECT 1
+                      FROM translation t
+                      WHERE t.translation_key = 'admin.appTranslations.languageCodeAlreadyExists'
+                        AND t.language = l.language
+                    );
+
+              - sql: |
+                    INSERT INTO translation (translation_key, language, default_value, active, version)
+                    SELECT
+                      'admin.internalStorage.translation.dialog.field.languageCodeHint',
+                      l.language,
+                      'Search by language name or code, for example English or EN.',
+                      l.active,
+                      0
+                    FROM (SELECT DISTINCT language, active FROM translation) l
+                    WHERE NOT EXISTS (
+                      SELECT 1
+                      FROM translation t
+                      WHERE t.translation_key = 'admin.internalStorage.translation.dialog.field.languageCodeHint'
+                        AND t.language = l.language
+                    );
+
+              - sql: |
+                    INSERT INTO translation (translation_key, language, default_value, active, version)
+                    SELECT
+                      'admin.internalStorage.translation.dialog.field.languageCodeRequired',
+                      l.language,
+                      'Language code is required.',
+                      l.active,
+                      0
+                    FROM (SELECT DISTINCT language, active FROM translation) l
+                    WHERE NOT EXISTS (
+                      SELECT 1
+                      FROM translation t
+                      WHERE t.translation_key = 'admin.internalStorage.translation.dialog.field.languageCodeRequired'
+                        AND t.language = l.language
+                    );
+
+              - sql: |
+                    INSERT INTO translation (translation_key, language, default_value, active, version)
+                    SELECT
+                      'admin.internalStorage.translation.dialog.field.languageCodePattern',
+                      l.language,
+                      'Please enter a two-letter language code.',
+                      l.active,
+                      0
+                    FROM (SELECT DISTINCT language, active FROM translation) l
+                    WHERE NOT EXISTS (
+                      SELECT 1
+                      FROM translation t
+                      WHERE t.translation_key = 'admin.internalStorage.translation.dialog.field.languageCodePattern'
+                        AND t.language = l.language
+                    );
+
+              - sql: |
+                    INSERT INTO translation (translation_key, language, default_value, active, version)
+                    SELECT
+                      'admin.internalStorage.translation.dialog.field.languageCodeInvalid',
+                      l.language,
+                      'Please select a valid ISO 639-1 language code.',
+                      l.active,
+                      0
+                    FROM (SELECT DISTINCT language, active FROM translation) l
+                    WHERE NOT EXISTS (
+                      SELECT 1
+                      FROM translation t
+                      WHERE t.translation_key = 'admin.internalStorage.translation.dialog.field.languageCodeInvalid'
+                        AND t.language = l.language
+                    );

--- a/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.7.0_14.yaml
+++ b/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.7.0_14.yaml
@@ -1,0 +1,35 @@
+databaseChangeLog:
+    - changeSet:
+          id: 38
+          author: Geoffrey Karnbach
+          changes:
+              - dropForeignKeyConstraint:
+                    baseTableName: inter_storage_translation
+                    constraintName: fk_inter_storage_trans_lang
+
+              - dropForeignKeyConstraint:
+                    baseTableName: inter_storage_translation_aud
+                    constraintName: fk_int_storage_tran_lang_aud
+
+              - sql: |
+                    UPDATE inter_storage_translation
+                    SET language_code = 'en'
+                    WHERE language_code = 'eng';
+
+              - sql: |
+                    UPDATE inter_storage_translation
+                    SET language_code = 'de'
+                    WHERE language_code = 'deu';
+
+              - sql: |
+                    UPDATE inter_storage_translation_aud
+                    SET language_code = 'en'
+                    WHERE language_code = 'eng';
+
+              - sql: |
+                    UPDATE inter_storage_translation_aud
+                    SET language_code = 'de'
+                    WHERE language_code = 'deu';
+
+              - dropTable:
+                    tableName: e_language

--- a/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.7.0_14.yaml
+++ b/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.7.0_14.yaml
@@ -11,25 +11,37 @@ databaseChangeLog:
                     baseTableName: inter_storage_translation_aud
                     constraintName: fk_int_storage_tran_lang_aud
 
-              - sql: |
-                    UPDATE inter_storage_translation
-                    SET language_code = 'en'
-                    WHERE language_code = 'eng';
+              - update:
+                  tableName: inter_storage_translation
+                  columns:
+                    - column:
+                        name: language_code
+                        value: en
+                  where: language_code = 'eng'
 
-              - sql: |
-                    UPDATE inter_storage_translation
-                    SET language_code = 'de'
-                    WHERE language_code = 'deu';
+              - update:
+                  tableName: inter_storage_translation
+                  columns:
+                    - column:
+                        name: language_code
+                        value: de
+                  where: language_code = 'deu'
 
-              - sql: |
-                    UPDATE inter_storage_translation_aud
-                    SET language_code = 'en'
-                    WHERE language_code = 'eng';
+              - update:
+                  tableName: inter_storage_translation_aud
+                  columns:
+                    - column:
+                        name: language_code
+                        value: en
+                  where: language_code = 'eng'
 
-              - sql: |
-                    UPDATE inter_storage_translation_aud
-                    SET language_code = 'de'
-                    WHERE language_code = 'deu';
+              - update:
+                  tableName: inter_storage_translation_aud
+                  columns:
+                    - column:
+                         name: language_code
+                         value: de
+                  where: language_code = 'deu'
 
               - dropTable:
                     tableName: e_language

--- a/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.x.yaml
+++ b/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.x.yaml
@@ -53,3 +53,7 @@ databaseChangeLog:
       file: org/damap/base/db/changeLog-4.x/changeLog-4.7.0_11.yaml
   - include:
       file: org/damap/base/db/changeLog-4.x/changeLog-4.7.0_12.yaml
+  - include:
+      file: org/damap/base/db/changeLog-4.x/changeLog-4.7.0_13.yaml
+  - include:
+      file: org/damap/base/db/changeLog-4.x/changeLog-4.7.0_14.yaml

--- a/src/test/java/org/damap/base/rest/InternalStorageResourceTest.java
+++ b/src/test/java/org/damap/base/rest/InternalStorageResourceTest.java
@@ -43,7 +43,7 @@ class InternalStorageResourceTest {
     validData.setActive(true);
 
     InternalStorageTranslationDO translation = new InternalStorageTranslationDO();
-    translation.setLanguageCode("eng");
+    translation.setLanguageCode("en");
     translation.setTitle("testStorageName");
     translation.setDescription("testStorageDescription");
     translation.setBackupFrequency("testBackupFrequency");

--- a/src/test/java/org/damap/base/rest/InternalStorageTranslationResourceTest.java
+++ b/src/test/java/org/damap/base/rest/InternalStorageTranslationResourceTest.java
@@ -139,7 +139,7 @@ class InternalStorageTranslationResourceTest {
     data.setStorageId(id);
     data.setTitle("Title");
     data.setBackupFrequency("Test Storage Backup Frequency ENG");
-    data.setLanguageCode("eng");
+    data.setLanguageCode("en");
     data.setDescription("Test Storage Description ENG");
 
     ValidatableResponse response =
@@ -151,7 +151,7 @@ class InternalStorageTranslationResourceTest {
             .post()
             .then()
             .statusCode(400);
-    response.body("message", startsWith("Translation for language code eng already exists"));
+    response.body("message", startsWith("Translation for language code en already exists"));
   }
 
   @Test
@@ -163,7 +163,7 @@ class InternalStorageTranslationResourceTest {
     data.setStorageId(id);
     data.setTitle("Test Storage Title DEU");
     data.setDescription("Test Storage Description DEU");
-    data.setLanguageCode("deu");
+    data.setLanguageCode("de");
     data.setBackupFrequency("Test Storage Backup Frequency DEU");
 
     // Correct the URL construction
@@ -200,7 +200,7 @@ class InternalStorageTranslationResourceTest {
     InternalStorageTranslationDO data = new InternalStorageTranslationDO();
     data.setTitle("Test Storage Title ENG");
     data.setDescription("Test Storage Description ENG");
-    data.setLanguageCode("eng");
+    data.setLanguageCode("en");
     data.setBackupFrequency("Test Storage Backup Frequency ENG");
 
     given()
@@ -222,7 +222,7 @@ class InternalStorageTranslationResourceTest {
     data.setId(ids.get(1));
     data.setTitle("Test Storage Title DEU");
     data.setDescription("Test Storage Description DEU");
-    data.setLanguageCode("deu");
+    data.setLanguageCode("de");
     data.setBackupFrequency("Test Storage Backup Frequency DEU");
     data.setStorageId(ids.get(0));
 

--- a/src/test/java/org/damap/base/util/TestDOFactory.java
+++ b/src/test/java/org/damap/base/util/TestDOFactory.java
@@ -439,7 +439,7 @@ public class TestDOFactory {
     internalStorageTranslation.setTitle("Test Storage Title ENG");
     internalStorageTranslation.setDescription(
         "Long winded yet brief description of the storage option");
-    internalStorageTranslation.setLanguageCode("eng");
+    internalStorageTranslation.setLanguageCode("en");
     internalStorageTranslation.persistAndFlush();
 
     if (generateTwo) {
@@ -448,7 +448,7 @@ public class TestDOFactory {
       internalStorageTranslation2.setTitle("Test Storage Title DEU");
       internalStorageTranslation2.setDescription(
           "Long winded yet brief description of the storage option");
-      internalStorageTranslation2.setLanguageCode("deu");
+      internalStorageTranslation2.setLanguageCode("de");
       internalStorageTranslation2.persistAndFlush();
 
       return List.of(


### PR DESCRIPTION
## Description

Feature / Bugfix / Database migration

#### What does this PR do?

This PR aligns app translation and internal storage translation language-code handling with ISO 639-1 two-letter language codes.

Previously, app translation languages could be created with arbitrary input, while internal storage translations were restricted to the legacy values `eng` and `deu` through backend validation and a database foreign key to `e_language`. This caused mismatches between app translations and internal storage translations once additional languages were added.

This PR changes that by:

- adding backend validation for ISO 639-1 two-letter language codes
- normalizing app translation language codes before creation
- normalizing and validating internal storage translation language codes before creation/update
- replacing the old internal storage validation that only allowed `eng` and `deu`
- adding translation keys for frontend validation messages
- migrating existing internal storage translation values:
  - `eng` → `en`
  - `deu` → `de`
- removing the old `e_language` database table restriction by dropping the related foreign keys and table

This makes app translations and internal storage translations use the same language-code format and prevents invalid language codes from being created through direct backend requests.

#### Breaking changes

Potentially breaking for consumers or existing data that still rely on the legacy internal storage language codes `eng` and `deu`.

A database migration is included to migrate existing values to the new ISO 639-1 format:

- `eng` becomes `en`
- `deu` becomes `de`

The old `e_language` lookup table is removed, so validation is now handled in the backend service layer instead of through the database foreign key.

#### Dependencies

Requires corresponding frontend changes to:

- use the same ISO 639-1 language-code list
- replace free-text/dropdown language fields with autocomplete
- submit normalized two-letter language codes such as `en`, `de`, `fr`
- handle migrated internal storage translations using `en` / `de` instead of `eng` / `deu`

