### PR TITLE
Add repository step dataset/retention translations

### DIFF
--- a/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.7.0_15.yaml
+++ b/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.7.0_15.yaml
@@ -1,0 +1,107 @@
+databaseChangeLog:
+    - changeSet:
+          id: 39
+          author: Laura
+          comment: Insert translations for the repository step dataset/retention table (frontend PR #538)
+          changes:
+              - sql: |
+                    INSERT INTO translation (translation_key, language, default_value, active, version)
+                    SELECT
+                      'dmp.steps.repositories.table.header.dataset',
+                      l.language,
+                      'Dataset',
+                      l.active,
+                      0
+                    FROM (SELECT DISTINCT language, active FROM translation) l;
+
+              - sql: |
+                    INSERT INTO translation (translation_key, language, default_value, active, version)
+                    SELECT
+                      'dmp.steps.repositories.table.header.deposit',
+                      l.language,
+                      'Deposit in repository',
+                      l.active,
+                      0
+                    FROM (SELECT DISTINCT language, active FROM translation) l;
+
+              - sql: |
+                    INSERT INTO translation (translation_key, language, default_value, active, version)
+                    SELECT
+                      'dmp.steps.repositories.table.header.retention',
+                      l.language,
+                      'Minimum retention period (all repositories)',
+                      l.active,
+                      0
+                    FROM (SELECT DISTINCT language, active FROM translation) l;
+
+              - sql: |
+                    INSERT INTO translation (translation_key, language, default_value, active, version)
+                    SELECT
+                      'dmp.steps.repositories.retention.assigned',
+                      l.language,
+                      'The retention period applies to this dataset across all repositories.',
+                      l.active,
+                      0
+                    FROM (SELECT DISTINCT language, active FROM translation) l;
+
+              - sql: |
+                    INSERT INTO translation (translation_key, language, default_value, active, version)
+                    SELECT
+                      'dmp.steps.repositories.retention.unassigned',
+                      l.language,
+                      'Assign this dataset to at least one repository to set a retention period.',
+                      l.active,
+                      0
+                    FROM (SELECT DISTINCT language, active FROM translation) l;
+
+              - sql: |
+                    INSERT INTO translation (translation_key, language, default_value, active, version)
+                    SELECT
+                      'dmp.steps.repositories.search',
+                      l.language,
+                      'Search',
+                      l.active,
+                      0
+                    FROM (SELECT DISTINCT language, active FROM translation) l;
+
+              - sql: |
+                    INSERT INTO translation (translation_key, language, default_value, active, version)
+                    SELECT
+                      'dmp.steps.repositories.recommended.headline',
+                      l.language,
+                      'Recommended Repositories',
+                      l.active,
+                      0
+                    FROM (SELECT DISTINCT language, active FROM translation) l;
+
+              - sql: |
+                    INSERT INTO translation (translation_key, language, default_value, active, version)
+                    SELECT
+                      'dmp.steps.repositories.view.button.recommended',
+                      l.language,
+                      'Recommended Repositories',
+                      l.active,
+                      0
+                    FROM (SELECT DISTINCT language, active FROM translation) l;
+
+              - sql: |
+                    INSERT INTO translation (translation_key, language, default_value, active, version)
+                    SELECT
+                      'dmp.steps.repositories.view.button.other',
+                      l.language,
+                      'Search other Repositories',
+                      l.active,
+                      0
+                    FROM (SELECT DISTINCT language, active FROM translation) l;
+
+              - update:
+                    tableName: translation
+                    columns:
+                        - column:
+                              name: default_value
+                              value: 'Search other Repositories'
+                    where: translation_key = 'dmp.steps.repositories.find.other'
+
+              - delete:
+                    tableName: translation
+                    where: translation_key = 'dmp.steps.repositories.question.datasets'

--- a/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.x.yaml
+++ b/src/main/resources/org/damap/base/db/changeLog-4.x/changeLog-4.x.yaml
@@ -57,3 +57,5 @@ databaseChangeLog:
       file: org/damap/base/db/changeLog-4.x/changeLog-4.7.0_13.yaml
   - include:
       file: org/damap/base/db/changeLog-4.x/changeLog-4.7.0_14.yaml
+  - include:
+      file: org/damap/base/db/changeLog-4.x/changeLog-4.7.0_15.yaml


### PR DESCRIPTION
Partner changeset for damap-frontend#538. Inserts the new repository-step keys

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/damap-org/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
  Config / DB (translations)

#### What does this PR do?
Partner changeset for damap-frontend#538. The new repository-step UI keys introduced in that PR (dataset/deposit/retention table headers, retention assigned/unassigned tooltips, search, recommended headline) had no rows in the translation table, so they would render as raw keys at runtime.

This adds Liquibase changeset changeLog-4.7.0_15.yaml (id 39) which inserts those keys across all existing languages mirroring the cross-language pattern in changeLog-4.7.0_13.yaml and updates the default_value of dmp.steps.repositories.find.other from "Find other repository" to "Search other Repositories".


#### Breaking changes
  None. Data-only migration; no schema, table, or column changes.

#### Code review focus
<!-- What you want the reviewer to focus on -->

#### Dependencies
  - damap-frontend#538 this PR supplies the translations consumed there.

### Checks
<!-- Adjust list as necessary -->
<!-- In case of DB changes make sure that names do not exceed 30 chars and that audit tables have been created/updated and do not contain FKs on entities. -->
- [ ] Tested with Oracle/PostgreSQL
- [ ] Export updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-<!-- insert issue number -->
