### PR TITLE
Include guidance in assessment results

### DIFF
--- a/src/main/java/org/damap/base/rest/evaluation/dto/EvaluationResultDTO.java
+++ b/src/main/java/org/damap/base/rest/evaluation/dto/EvaluationResultDTO.java
@@ -22,4 +22,5 @@ public class EvaluationResultDTO {
   private String assessmentTarget;
   private String wasGeneratedBy;
   private String outputFromTest;
+  private GuidanceDTO guidance;
 }

--- a/src/main/java/org/damap/base/rest/evaluation/dto/GuidanceDTO.java
+++ b/src/main/java/org/damap/base/rest/evaluation/dto/GuidanceDTO.java
@@ -1,0 +1,13 @@
+package org.damap.base.rest.evaluation.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+import lombok.Data;
+
+/** GuidanceDTO class. Human-readable explanation accompanying an evaluation result. */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GuidanceDTO {
+  private String summary;
+  private List<GuidanceIssueDTO> issues;
+}

--- a/src/main/java/org/damap/base/rest/evaluation/dto/GuidanceIssueDTO.java
+++ b/src/main/java/org/damap/base/rest/evaluation/dto/GuidanceIssueDTO.java
@@ -1,0 +1,12 @@
+package org.damap.base.rest.evaluation.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+/** GuidanceIssueDTO class. A single dataset-level issue within an evaluation guidance. */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GuidanceIssueDTO {
+  private String dataset;
+  private String reason;
+}


### PR DESCRIPTION
Feature: Include Guidance in evaluation results

### What does this PR do?

Results from the Evaluation Service can now include a new field called "guidence". This object is now sent to the frontend.

[Frontend PR](https://github.com/damap-org/damap-frontend/pull/554)