### PR TITLE
Byte Size: Specify long (int64) instead of default int32

### DIFF
--- a/src/main/java/org/damap/base/rda/dmpcommonstandard/DatasetMapper.java
+++ b/src/main/java/org/damap/base/rda/dmpcommonstandard/DatasetMapper.java
@@ -69,7 +69,7 @@ public class DatasetMapper extends AbstractMapper {
     }
     var size = datasetDO.getSize();
     if (size != null) {
-      distribution.setByteSize(Math.toIntExact(size));
+      distribution.setByteSize(size);
     }
     result.setDescription(datasetDO.getDescription());
     var personalData = datasetDO.getPersonalData();

--- a/src/main/resources/org/damap/base/dmpcommonstandard/openapi.yaml
+++ b/src/main/resources/org/damap/base/dmpcommonstandard/openapi.yaml
@@ -1848,6 +1848,7 @@ components:
             - "2030-06-30"
         byte_size:
           type: integer
+          format: int64
           title: Byte Size
           description: Size in bytes.
           examples:


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/damap-org/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
<!-- Feature/Bugfix/CI/Refactoring/Config/Documentation/... -->
Bugfix
#### What does this PR do?
<!-- Changes introduced by this PR - what happened before, what happens now -->
Because the `openapi.yaml` spec does not specify a format for the `byte_size` field of the `Distribution` object, `int32` is taken as default. However, this is inadequate for byte sizes, since exporting the RDA JSON DMP with a dataset of more than roughly 2.2 GB would already result in an Integer overflow. Currently, an internal server error (500) is generated without proper error handling. This will be addressed in another slightly larger PR shortly, along with some other issues with the mappers.
